### PR TITLE
Validate tables of a data package

### DIFF
--- a/man/validate_ecocomDP.Rd
+++ b/man/validate_ecocomDP.Rd
@@ -13,6 +13,9 @@ tables.}
 \item{data.list}{(list of data frames) A named list of data frames containing the L1
 tables. Data frame tables must be named after the file name from 
 which they were read, including the extension.}
+
+\item{package.id}{(character) Package identifier (e.g. 'edi.101.1') containing ecocomDP
+tables to be validated.}
 }
 \value{
 A validation report to the RStudio console window. When an issue is 

--- a/man/validate_table_names.Rd
+++ b/man/validate_table_names.Rd
@@ -26,6 +26,8 @@ structure:
         }
     }
 }}
+
+\item{file.names}{(character) Vector of file names.}
 }
 \value{
 If table names are valid, then the corresponding table names are


### PR DESCRIPTION
Test whether the tables of an EDI Data Package comply with ecocomDP validation criteria. This functionality supports routine checks on the quality of ecocomDP data packages and will be used to screen ecocomDP before entering the aggregation process.