### PR TITLE
refactor NEON mapping code, add arguments to save and read "raw" NEON data locally

### DIFF
--- a/NEON_dev_script/NOTES_on_edits_to_NEON_SS_scripts.txt
+++ b/NEON_dev_script/NOTES_on_edits_to_NEON_SS_scripts.txt
@@ -35,6 +35,7 @@ TODO --
  PLANT				percent cover	percent of plot area covered by taxon
  SMALL_MAMMAL		count			unique individuals per 100 trap nights per plot per month
  ZOOPLANKTON		density			count per liter
+ TICK				abundance		count per square meter 
  TICK_PATHOGENS		positivity rate	positive tests per pathogen per sampling event
  
 ##################################################################

--- a/NEON_dev_script/TESTING_ecocomDP_calls_with_NEON_updates_20201215.R
+++ b/NEON_dev_script/TESTING_ecocomDP_calls_with_NEON_updates_20201215.R
@@ -18,6 +18,34 @@ View(my_search_result)
 
 #BEETLE update
 
+my_result <- neonUtilities::loadByProduct(
+  dpID = "DP1.10022.001",
+  site = c('ABBY','BARR'),
+  startdate = "2019-06",
+  enddate = "2019-09",
+  token = Sys.getenv("NEON_TOKEN"),
+  package = "basic",
+  check.size = FALSE)
+
+my_neon_dir <- "my_result"
+if(!my_neon_dir %in% list.files()) dir.create(my_neon_dir)
+
+
+
+
+my_result <- neonUtilities::zipsByProduct(
+  dpID = "DP1.10022.001",
+  site = c('ABBY','BARR'),
+  startdate = "2019-06",
+  enddate = "2019-09",
+  token = Sys.getenv("NEON_TOKEN"),
+  package = "basic",
+  check.size = FALSE,
+  savepath = "my_result")
+
+
+
+
 my_result <- ecocomDP:::map_neon.ecocomdp.10022.001.001(
   site = c('ABBY','BARR'),
   startdate = "2019-06",
@@ -35,6 +63,7 @@ my_result_mapped <- ecocomDP:::map_neon_data_to_ecocomDP(
   token = Sys.getenv("NEON_TOKEN"),
   check.size = FALSE)
 
+
 my_result_read_data <- read_data(
   id = "neon.ecocomdp.10022.001.001",
   site = c('ABBY','BARR'),
@@ -43,7 +72,20 @@ my_result_read_data <- read_data(
   enddate = "2021-02",
   token = Sys.getenv("NEON_TOKEN"),
   check.size = FALSE)
+  
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10022.001.001",
+  site = c('ABBY','BARR'),
+  startdate = "2019-06",
+  # enddate = "2019-09",
+  enddate = "2021-02",
+  neon.data.save.path = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
 
+
+
+my_result_back_in <- read_from_files(data.path = "C:/Users/esokol/Documents/Git/FORKS/ecocomDP/my_result/neon.ecocomdp.10022.001.001")
 #dupes for obs_id below -- dups have different taxon_ids 
 # "9ec05998-a868-4eb8-8691-3c28a025f358"
 # "9a93953e-9260-4b43-95e9-b05a55338f08"

--- a/NEON_dev_script/TESTING_ecocomDP_calls_with_NEON_updates_20201215.R
+++ b/NEON_dev_script/TESTING_ecocomDP_calls_with_NEON_updates_20201215.R
@@ -584,16 +584,6 @@ obs_anci$observation_ancillary_id %>% duplicated() %>% sum()
 
 rm(list=ls())
 
-my_result <- map_neon.ecocomdp.10093.001.001(
-  site = c("BART","DSNY"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  package = "basic",
-  check.size = FALSE)
-
-my_result$dataset_summary
-
 my_result_read_data <- read_data(
   id = "neon.ecocomdp.10093.001.001",
   site= c("NIWO","DSNY", "BART"), 
@@ -601,6 +591,12 @@ my_result_read_data <- read_data(
   enddate = "2017-11",
   token = Sys.getenv("NEON_TOKEN"),
   check.size = FALSE)
+
+list.files("my_result")
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10093.001.001",
+  neon.data.read.path = "my_result/DP1.10093.001_20210320222321.RDS")
 
 my_result_read_data[[1]]$validation_issues
 my_result_read_data[[1]]$metadata$data_package_info

--- a/NEON_dev_script/TESTING_local_neon_save_20210320.R
+++ b/NEON_dev_script/TESTING_local_neon_save_20210320.R
@@ -1,0 +1,291 @@
+# DATA
+# testing with NEON algae "DP1.20166.001" -- returns data
+# my_search_result$id[1]
+# my_search_result$title[1]
+# my_search_result$source_id[1]
+
+# library(tidyverse)
+
+
+
+my_search_result <- ecocomDP::search_data("NEON")
+View(my_search_result)
+
+
+
+###############################################
+###############################################
+
+#BEETLE update
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10022.001.001",
+  site = c('ABBY','BARR'),
+  startdate = "2019-06",
+  # enddate = "2019-09",
+  enddate = "2021-02",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+
+# 
+# my_result_read_data <- read_data(
+#   id = "neon.ecocomdp.10022.001.001",
+#   neon.data.read.path = "my_result/DP1.10022.001_20210320204805.RDS")
+# 
+# neon_raw_data <- readRDS("my_result/DP1.10022.001_20210320204805.RDS")
+# 
+# my_result_read_data <- read_data(
+#   id = "neon.ecocomdp.10022.001.001",
+#   neon.data.list = neon_raw_data)
+
+
+
+# list.files("my_result/")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+
+###############################################
+###############################################
+
+#BIRD update
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10003.001.001",
+  site = c('ABBY','BARR'),
+  startdate = "2019-06",
+  # enddate = "2019-09",
+  enddate = "2021-02",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10003.001.001",
+  neon.data.list = NA)
+
+###############################################
+###############################################
+
+# HERPS
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10022.001.002",
+  site= c("NIWO","DSNY"),
+  startdate = "2016-01",
+  enddate = "2017-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10022.001.002",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# MOSQUITO
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10043.001.001",
+  site= c("NIWO","DSNY"),
+  startdate = "2016-01",
+  enddate = "2018-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10043.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# PLANT
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10058.001.001",
+  site= c("NIWO","DSNY"),
+  startdate = "2016-01",
+  enddate = "2017-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10058.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# SMALL_MAMMALS
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10072.001.001",
+  site= c("NIWO","DSNY"),
+  startdate = "2016-01",
+  enddate = "2017-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10072.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# TICK_PATHOGEN
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10092.001.001",
+  site = c("ORNL","OSBS"),
+  startdate = "2016-01",
+  enddate = "2017-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10092.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# TICKS
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10093.001.001",
+  site = c("ORNL","OSBS"),
+  startdate = "2016-01",
+  enddate = "2017-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+  
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10093.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# FISH
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20107.001.001",
+  site = c('COMO','LECO'),
+  startdate = "2016-01",
+  enddate = "2018-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20107.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# MACROINVERTEBRATE
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20120.001.001",
+  site = c('COMO','LECO'),
+  startdate = "2019-06",
+  enddate = "2019-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20120.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# ALGAE
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20166.001.001",
+  site = c('COMO','LECO'),
+  startdate = "2017-06",
+  enddate = "2019-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20166.001.001",
+  neon.data.list = NA)
+###############################################
+###############################################
+
+# ZOOPS
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20219.001.001",
+  site = c("BARC","SUGG"),
+  startdate = "2016-01",
+  enddate = "2017-11",
+  neon.data.save.dir = "my_result",
+  token = Sys.getenv("NEON_TOKEN"),
+  check.size = FALSE)
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20219.001.001",
+  neon.data.list = NA)

--- a/NEON_dev_script/tick_code/01_data_tick.R
+++ b/NEON_dev_script/tick_code/01_data_tick.R
@@ -1,0 +1,437 @@
+# Download and clean tick data 
+# Authors: Wynne Moss, Melissa Chen, Brendan Hobart, Matt Bitters
+# Date: 2/11/2021
+
+### Script to create tidy dataset of NEON tick abundances
+# link data from lab and field
+# filter out poor quality data
+# rectify count issues
+# export in tidy format
+
+### Load packages
+# 
+# library(tidyverse) # for data wrangling and piping (dplyr probably ok)
+# library(neonUtilities) # for downloading data (use GitHub version)
+# library(lubridate) # for finding year from dates
+# library(stringr)
+
+
+#  LOAD TICK DATA FROM NEON OR FILE SOURCE 
+
+# Tick Abundance and field data data are in DP1.10093.001
+
+
+# If data weren't already downloaded, download full NEON dataset
+# As of 7/6/20 loadByProduct had bugs if using the CRAN version of the package
+# Downloading the package NeonUtilities via Github solves the issue
+
+
+Tick_all <- loadByProduct(dpID = neon.data.product.id, package = "expanded", ...)
+
+# unlist
+tck_taxonomyProcessed = Tick_all$tck_taxonomyProcessed
+tck_fielddata = Tick_all$tck_fielddata
+# tck_taxonomyProcessed and tck_fielddata are the two datasets we want 
+
+
+# NOTES ON GENERAL DATA ISSUES #
+
+
+# Issue 1: the latency between field (30 days) and lab (300 days) is different
+# In 2019, tick counts were switched over to the lab instead of the field
+# If the samples aren't processed yet, there will be an NA for some or all the counts (regardless of whether ticks were present)
+# If targetTaxaPresent == "N" we will assign the counts a 0 (there is no lab data pending)
+# If targetTaxaPresent == "Y" but no associated field record, we will keep counts as NA but define that there are counts pending
+# Yearly trends may show issues for recent years because ONLY 0s are in. 
+
+# Issue 2: larva counts
+# larvae were not always counted or ID'd in earlier years
+# there are excess larvae counted in the field but not IDd in the lab -- assign these to order level
+
+# Issue 3: discrepancies between field counts and lab counts
+# Often lab counts are less than field because they stop counting at a certain limit
+# This is not always recorded in the same way
+# Other times ticks were miscounted or lost on either end
+# Probably OK to ignore most minor issues, and make best attempt at more major issues
+# Drop remaining records that are confusing
+
+#### NAs
+# replace empty characters with NAs instead of ""
+repl_na <- function(x) ifelse(x=="", NA, x)
+
+
+# CLEAN TICK TAXONOMY DATA #
+
+### replace "" with NA
+tck_tax_filtered = dplyr::mutate_if(tck_taxonomyProcessed, .predicate = is.character, .funs = repl_na) %>% tibble::as_tibble() 
+
+### only retain lab records that have associated field data
+
+tck_tax_filtered =  dplyr::filter(tck_tax_filtered, sampleID %in% tck_fielddata$sampleID)  # none lost
+
+### check sample quality flags
+# retain only samples deemed "OK"
+tck_tax_filtered = dplyr::filter(tck_tax_filtered, sampleCondition == "OK")
+
+### require date and taxon ID
+# samples without id's are not ticks! (n = 3) remove them
+tck_tax_filtered = dplyr::filter(tck_tax_filtered, !is.na(acceptedTaxonID))
+
+# require a date (no records are lost)
+tck_tax_filtered = dplyr::filter(tck_tax_filtered, !is.na(identifiedDate)) 
+
+### sex or age columns
+# required (no records are lost)
+tck_tax_filtered = dplyr::filter(tck_tax_filtered, !is.na(sexOrAge))
+
+# require counts (no records are lost)
+tck_tax_filtered = dplyr::filter(tck_tax_filtered, !is.na(individualCount))
+
+# create a lifestage column so tax counts can be compared to field data
+tck_tax_filtered = dplyr::mutate(tck_tax_filtered, lifeStage = dplyr::case_when(sexOrAge == "Male" | sexOrAge == "Female" | sexOrAge == "Adult" ~ "Adult",
+                                                  sexOrAge == "Larva" ~ "Larva",
+                                                  sexOrAge == "Nymph" ~ "Nymph")) 
+
+### rename taxonomy columns distinctly from field data
+
+# rename columns containing data unique to each dataset
+colnames(tck_fielddata)[colnames(tck_fielddata)=="uid"] <- "uid_field"
+colnames(tck_fielddata)[colnames(tck_fielddata)=="sampleCondition"] <- "sampleCondition_field"
+colnames(tck_fielddata)[colnames(tck_fielddata)=="remarks"] <- "remarks_field"
+colnames(tck_fielddata)[colnames(tck_fielddata)=="dataQF"] <- "dataQF_field"
+colnames(tck_fielddata)[colnames(tck_fielddata)=="publicationDate"] <- "publicationDate_field"
+
+colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="uid"] <- "uid_tax"
+colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="sampleCondition"] <- "sampleCondition_tax"
+colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="remarks"] <- "remarks_tax"
+colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="dataQF"] <- "dataQF_tax"
+colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="publicationDate"] <- "publicationDate_tax"
+
+# merge counts from male/female into one adult class
+# summing male and female counts (assuming biodiversity analyses won't be sex specific)
+
+tck_tax_wide = tck_tax_filtered %>% group_by(sampleID, acceptedTaxonID, lifeStage) %>%
+  summarise(individualCount = sum(individualCount, na.rm = TRUE)) %>%
+  # now make it wide;  only one row per sample id
+  pivot_wider(id_cols = sampleID,  names_from = c(acceptedTaxonID, lifeStage), values_from = individualCount, values_fill = 0)  %>% 
+  ungroup()
+
+# each row is now a unique sample id (e.g. a site x species matrix)
+
+
+# CLEAN TICK FIELD DATA #
+
+tck_fielddata = dplyr::mutate_if(tck_fielddata, .predicate = is.character, .funs = repl_na) 
+
+#### Quality Flags 
+# remove samples that had logistical issues
+# keep only those with NA in samplingImpractical 
+# this is ~11% as of 2020 (many related to COVID)
+
+tck_fielddata_filtered = dplyr::filter(tck_fielddata, is.na(samplingImpractical)|samplingImpractical == "OK")
+
+# make sure all record with ticks were assigned a sample ID
+tck_fielddata_filtered = dplyr::filter(tck_fielddata_filtered, !(targetTaxaPresent=="Y" & is.na(sampleID))) 
+
+
+# MERGE AND RESOLVE COUNTS #
+
+
+#### merge the field and lab data and figure out where counts disagree (pre-2019)
+# add non-existent columns to eventually put unidentified counts into
+if(!"IXOSP2_Adult" %in% colnames(tck_tax_wide)) {tck_tax_wide$IXOSP2_Adult = 0}
+if(!"IXOSP2_Nymph" %in% colnames(tck_tax_wide)) {tck_tax_wide$IXOSP2_Nymph = 0}
+if(!"IXOSP2_Larva" %in% colnames(tck_tax_wide)) {tck_tax_wide$IXOSP2_Larva = 0}
+
+# get a list of columns containing taxonomic counts
+tax_cols = tck_tax_wide %>% ungroup() %>%  dplyr::select(-sampleID) %>% colnames()
+
+#### left-join field data to lab data using sample ID
+tck_merged = tck_fielddata_filtered %>% dplyr::left_join(tck_tax_wide, by = "sampleID") 
+
+# add in the lab taxonomy remarks
+tck_merged = tck_tax_filtered  %>% dplyr::filter(!is.na(dataQF_tax)) %>%  group_by(sampleID) %>% 
+  summarise(dataQF_tax = paste0(dataQF_tax, collapse = " "), remarks_tax = paste0(remarks_tax, collapse = " ")) %>% 
+  dplyr::select(sampleID, dataQF_tax, remarks_tax) %>% ungroup() %>%  dplyr::right_join(tck_merged) 
+
+
+#### fill in 0s
+# if target taxa are not present, fill counts as 0s
+for(i in 1:length(tax_cols)){
+  tck_merged[which(tck_merged$targetTaxaPresent =="N"), which(colnames(tck_merged) == tax_cols[i])] = 0
+} # this will fill in recent years data too
+
+
+### get totals from the lab for comparisons to field counts
+tck_merged = tck_merged %>% dplyr::mutate(Total_Lab_Adult = rowSums(across(contains("_Adult"))),
+                      Total_Lab_Nymph = rowSums(across(contains("_Nymph"))),
+                      Total_Lab_Larva = rowSums(across(contains("_Larva")))) 
+
+###### get rid of/fix data with missing info 
+# 2014 and 2015 have some missing field larvae count 
+# filter to samples where there is no field larvae count but there is a lab larvae count
+field_larvae_na = dplyr::filter(tck_merged, targetTaxaPresent=="Y") %>% dplyr::filter(is.na(larvaCount), !is.na(Total_Lab_Larva)) %>% 
+  dplyr::mutate(year = lubridate::year(collectDate)) %>% dplyr::filter(year<2019) %>% 
+  dplyr::filter(!is.na(adultCount), !is.na(nymphCount)) %>% dplyr::pull(sampleID) 
+
+# replace the field larvae counts with the lab larvae count (not really necessary as we will be using the field data anyways)
+tck_merged$larvaCount[which(tck_merged$sampleID%in%field_larvae_na)] = tck_merged$Total_Lab_Larva[which(tck_merged$sampleID%in%field_larvae_na)]
+
+# check for other samples where there are missing counts prior to 2019 
+# drop those records
+# filter to samples where there is a NA in one of the field counts and it is prior to 2019
+# these are mostly legacy data and are not very abundant
+no_counts = dplyr::filter(tck_merged, targetTaxaPresent=="Y") %>% dplyr::filter(is.na(adultCount)|is.na(larvaCount)|is.na(nymphCount)) %>% 
+  dplyr::mutate(year = lubridate::year(collectDate)) %>% dplyr::filter(year<2019) %>% dplyr::pull(sampleID) 
+
+tck_merged = dplyr::filter(tck_merged, !sampleID %in% no_counts)
+
+rm(field_larvae_na, no_counts)
+
+#### get summed lab vs. field counts for comparisons ####
+tck_merged = tck_merged %>% dplyr::rowwise() %>% dplyr::mutate(totalFieldCount = sum(adultCount, larvaCount, nymphCount), # calculate total tick count from field data
+         totalLabCount = sum(Total_Lab_Adult, Total_Lab_Nymph, Total_Lab_Larva)) %>%  # calculate total tick count from lab data
+  ungroup()
+
+# check for field data that don't have associated lab data 
+# e.g. there is a field count but no taxonomy
+# these should be removed as we don't know the species
+missing_lab = dplyr::filter(tck_merged, !is.na(totalFieldCount) & is.na(totalLabCount)) %>% dplyr::pull(sampleID) 
+
+tck_merged = dplyr::filter(tck_merged, !(!is.na(sampleID) & sampleID %in% missing_lab)) 
+
+rm(missing_lab)
+
+# FIX COUNT DISCREPANCIES 
+
+# first flag where we have discrepancies in count that we need to fix
+tck_merged = tck_merged %>% 
+  dplyr::mutate(Discrepancy = dplyr::case_when(
+    is.na(adultCount) & is.na(nymphCount) & is.na(larvaCount) & targetTaxaPresent=="Y" & !is.na(totalLabCount) ~"LAB COUNT ONLY", # no field counts but lab counts exist (2019 onwards)
+    (is.na(adultCount) | is.na(nymphCount) | is.na(larvaCount)) & targetTaxaPresent=="Y" & year(collectDate)>2018 ~"COUNT PENDING", # still waiting on lab counts
+    totalFieldCount==0 & totalLabCount == 0 ~ "NONE", # no ticks; no discrepancy
+    totalFieldCount >0 & totalLabCount > 0 & totalFieldCount==totalLabCount~"NONE",  # matching counts; no discrepancy
+    targetTaxaPresent=="N"~"NONE", # no ticks; no discrepancy
+    totalFieldCount > totalLabCount ~ "FIELD COUNT GREATER",
+    totalFieldCount < totalLabCount ~ "LAB COUNT GREATER"
+)) 
+
+
+## FIX COUNTS 1: ONLY A SUBSET OF LARVAE WERE SAMPLED/COUNTED
+
+# if there are more larvae in the field than lab and a quality flag add the remaining larvae to unidentified order
+
+add_unknown_larvae = tck_merged %>% dplyr::filter(dataQF_tax == "ID lab count subsample of total field larvae") %>% # flag indicating the lab didn't count all larvae
+  dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% # larvae in the field > larvae in lab
+  dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in larvae is equal to the entire discrepancy
+  dplyr::pull(sampleID)  # if so, pull those sample IDs
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Larva = dplyr::case_when( 
+  sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy in larvae to the order level (IXOSP2_Larva)
+  TRUE~IXOSP2_Larva
+))  
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] = "FIXED" # remove the flag
+rm(add_unknown_larvae)
+
+# if there are more larvae in the field than lab and there is a note about invoicing, add remaining larvae
+add_unknown_larvae = tck_merged %>% dplyr::filter(stringr::str_detect(remarks_tax, "invoice")) %>% # flag that the lab reached an invoicing limit
+  dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>%
+  dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in larvae is equal to the entire discrepancy
+  dplyr::pull(sampleID)  # if so pull those sample IDs
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Larva = dplyr::case_when(
+  sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Larva)) 
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] = "FIXED" # remove the flag
+rm(add_unknown_larvae)
+
+# another indicator that not all the larvae were counted
+add_unknown_larvae = tck_merged %>% dplyr::filter(stringr::str_detect(remarks_tax, "possibly subsampled in ID lab counts")) %>%  # flag indicating the lab didn't count all larvae
+  dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>%
+  dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in larvae is equal to the entire discrepancy
+  pull(sampleID)  # if so pull those sample IDs
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Larva = dplyr::case_when(
+  sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Larva)) 
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] = "FIXED"
+rm(add_unknown_larvae)
+
+## do the same for nymphs
+add_unknown_nymph = tck_merged %>% dplyr::filter(stringr::str_detect(remarks_tax, "possibly subsampled in ID lab counts")) %>%  # flag indicating the lab didn't count all larvae
+  dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>%
+  dplyr::filter((nymphCount - Total_Lab_Nymph)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in nymphs is equal to the entire discrepancy
+  dplyr::pull(sampleID) 
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Nymph= dplyr::case_when(
+  sampleID %in% add_unknown_nymph ~ IXOSP2_Nymph + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Nymph)) 
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_nymph] = "FIXED"
+rm(add_unknown_nymph)
+
+##  FIX COUNTS 2: LARVA COUNT RECORDED AS 1  
+# NEON working on fixing this one
+# in some years, the lab accidentally put larvae as 1 but the field count says it should be higher
+add_unknown_larvae = tck_merged %>% dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% 
+  dplyr::filter(str_detect(dataQF_tax, "field larva count higher")) %>% dplyr::filter(year(collectDate) %in% c(2016, 2017)) %>% 
+  dplyr::filter(Total_Lab_Larva==1) %>%   # flag indicating the lab assigned all as a 1 
+  dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>% dplyr::pull(sampleID) 
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Larva = dplyr::case_when(
+  sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Larva)) 
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] = "FIXED"
+rm(add_unknown_larvae)
+
+add_unknown_larvae = tck_merged %>% dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% 
+  dplyr::filter(dataQF_field == "field larva count higher than ID lab (PDE >25%)") %>% dplyr::filter(Total_Lab_Larva == 1) %>% 
+  dplyr::pull(sampleID)
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Larva = dplyr::case_when(
+  sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Larva)) 
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] = "FIXED"
+rm(add_unknown_larvae)
+
+## FIX COUNTS 3: ADULTS WENT MISSING 
+add_unknown_adult = tck_merged %>% dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% 
+  dplyr::filter(dataQF_field == "field adult count higher than ID lab (PDE >25%)") %>%  # a few missing adults
+  dplyr::pull(sampleID) 
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Adult= dplyr::case_when(
+  sampleID %in% add_unknown_adult ~ IXOSP2_Adult + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Adult)) 
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_adult] = "FIXED"
+rm(add_unknown_adult)
+
+## FIX COUNTS 4: IGNORE MINOR DISCREPANCIES
+# if the difference is small, we will use the taxonomy data and ignore the discrepancy 
+
+# less than 5 individuals
+minor_discrep = tck_merged %>% dplyr::filter(Discrepancy == "FIELD COUNT GREATER", totalFieldCount-totalLabCount<5) %>% 
+  pull(sampleID)   # get records where the differences < 5 ticks
+tck_merged$Discrepancy[tck_merged$sampleID %in% minor_discrep] = "MINOR"
+rm(minor_discrep)
+
+# less than 10%
+minor_discrep = tck_merged %>% dplyr::filter(Discrepancy == "FIELD COUNT GREATER", (totalFieldCount-totalLabCount)/totalFieldCount<.1) %>%
+  dplyr::pull(sampleID)  # records where the difference is <10%
+tck_merged$Discrepancy[tck_merged$sampleID %in% minor_discrep] = "MINOR"
+rm(minor_discrep)
+
+## FIX COUNTS 6: MORE THAN ONE ERROR 
+# wrong lifestage ID and wrong counts... 
+
+# more than 500 larvae -- the lab will not count all of them
+add_unknown_larvae = tck_merged %>% dplyr::filter(Discrepancy == "FIELD COUNT GREATER", larvaCount>Total_Lab_Larva, larvaCount>500) %>% pull(sampleID) 
+
+tck_merged = tck_merged %>% dplyr::mutate(IXOSP2_Larva = dplyr::case_when(
+  sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+  TRUE~IXOSP2_Larva))
+
+tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] = "FIXED"
+rm(add_unknown_larvae)
+
+
+## GET RID OF ANY UNSOLVED MYSTERIES 
+# (tck_merged %>% dplyr::filter(Discrepancy =="FIELD COUNT GREATER") %>% nrow())/nrow(tck_merged %>% filter(targetTaxaPresent=="Y", Discrepancy != "COUNT PENDING"))
+# 2 % of the counted records have unsolved mysteries 
+# (tck_merged %>% dplyr::filter(Discrepancy =="FIELD COUNT GREATER") %>% nrow())/nrow(tck_merged)
+# > 1% of total records have unsolved mysteries 
+
+# if less than 1 percent of records are unresolved, get rid of them
+if((tck_merged %>% dplyr::filter(Discrepancy =="FIELD COUNT GREATER") %>% nrow())/nrow(tck_merged) < 0.05){
+  tck_merged = tck_merged %>% dplyr::filter(Discrepancy !="FIELD COUNT GREATER") 
+}
+table(tck_merged$Discrepancy)
+
+#### OTHER Q/C STEPS 
+# add a column to designate samples for which counts have not been assigned yet
+# this is for recent data where the field info is published but no associated lab data
+tck_merged = tck_merged  %>% 
+  dplyr::mutate(COUNT_PENDING = dplyr::case_when(targetTaxaPresent == "Y" & (is.na(adultCount) | is.na(larvaCount) | is.na(nymphCount)) & is.na(totalLabCount)~"Y",
+                                   !is.na(totalLabCount)~"N")) 
+
+
+# check that all of the rows WITHOUT a sample ID have no ticks
+# tck_merged %>% dplyr::filter(is.na(sampleID)) %>% dplyr::pull(targetTaxaPresent) %>% table() # true
+
+# check that all the rows WITH a sample ID have ticks
+# tck_merged %>% dplyr::filter(!is.na(sampleID)) %>% dplyr::pull(targetTaxaPresent) %>% table() # true
+
+# check that drags with ticks present have a sample ID
+# tck_merged %>% dplyr::filter(targetTaxaPresent == "Y" & is.na(sampleID)) # none are missing S.ID
+
+#### Check Counts vs. NAs 
+
+# make sure samples with ticks present have counts or are flagged
+# tck_merged %>% dplyr::filter(targetTaxaPresent == "Y") %>%
+  # dplyr::filter(is.na(adultCount) & is.na(nymphCount) & is.na(larvaCount)) %>% 
+  # group_by(COUNT_PENDING) %>% summarise(n=n())
+
+# if ticks are present and there aren't counts pending, there should not be any NAs in counts
+# tck_merged %>% dplyr::filter(targetTaxaPresent == "Y", COUNT_PENDING=="N") %>% dplyr::select(tax_cols) %>% colSums()
+
+#### Final notes on count data
+# note that some of these could have a "most likely" ID assigned based on what the majority of IDs are
+# for now don't attempt to assign. 
+# the user can decide what to do with the IXOSP2 later (e.g. assign to lower taxonomy)
+# from this point on, trust lab rather than field counts because lab were corrected if discrepancy exists
+rm(repl_na, tax_cols)
+
+
+# RESHAPE FINAL DATASET
+
+
+# will depend on the end user but creating two options
+# note that for calculation of things like richness, might want to be aware of the level of taxonomic resolution
+
+taxon.cols = tck_merged %>% dplyr::select(-contains("Total")) %>%  dplyr::select(contains(c("_Larva", "_Nymph", "_Adult"))) %>% colnames()   # columns containing counts per taxon
+
+
+### option 1) long form data including 0s
+
+# get rid of excess columns (user discretion)
+tck_merged_final = tck_merged %>% dplyr::select(-Discrepancy, -totalLabCount, -totalFieldCount, -Total_Lab_Adult, -Total_Lab_Larva, 
+                                          -Total_Lab_Nymph,-publicationDate_field, -measuredBy, -larvaCount, -nymphCount, -adultCount,
+                                          -coordinateUncertainty, -elevationUncertainty,
+                                          -samplingImpractical, -dataQF_field, -remarks_field, -remarks_tax,-publicationDate_field) %>% 
+  dplyr::rename(countPending = COUNT_PENDING)
+# long form data
+tck_merged_final = tck_merged_final %>% pivot_longer(cols = all_of(taxon.cols), names_to = "Species_LifeStage", values_to = "IndividualCount") %>%
+  separate(Species_LifeStage, into = c("acceptedTaxonID", "LifeStage"), sep = "_", remove = FALSE) 
+
+# add in taxonomic resolution
+
+tax_rank = tck_taxonomyProcessed %>% group_by(acceptedTaxonID) %>% dplyr::summarise(taxonRank =  first(taxonRank), scientificName= first(scientificName)) 
+
+tck_merged_final = tck_merged_final %>% dplyr::left_join(tax_rank, by = "acceptedTaxonID") 
+
+
+tck_site_species_table = tck_merged_final %>% dplyr::select(uid_field, acceptedTaxonID, IndividualCount) %>% group_by(uid_field, acceptedTaxonID) %>%
+  dplyr::summarise(IndividualCount =  sum(IndividualCount)) %>% pivot_wider(id_cols = uid_field, names_from = acceptedTaxonID, values_from = IndividualCount) 
+
+tck_site_species_env = tck_fielddata_filtered %>% dplyr::filter(uid_field %in% tck_site_species_table$uid_field) %>% dplyr::select(-adultCount, -nymphCount, -larvaCount) %>%
+  dplyr::left_join(tck_merged_final %>% dplyr::select(uid_field, countPending)) 
+
+
+# EXPORT DATA #
+
+saveRDS(tck_site_species_env, "data/tck_sitexspecies_env.Rdata")
+saveRDS(tck_merged_final, "data/tck_longform.Rdata")
+
+# NOTES FOR END USERS  #
+
+# be aware of higher order taxa ID -- they are individuals ASSIGNED at a higher taxonomic class, rather than the sum of lower tax. class
+# higher order taxonomic assignments could be semi-identified by looking at most likely ID (e.g. if 200 of 700 larvae are IXOSPAC, very likely that the Unidentified larvae are IXOSPAC)
+# unidentified could be changed to IXOSPP across the board 
+# All combos of species-lifestage aren't in the long form (e.g. if there were never IXOAFF_Adult, it will be missing instead of 0)
+
+

--- a/NEON_dev_script/tick_code/02_data_tick_ecocomDP.R
+++ b/NEON_dev_script/tick_code/02_data_tick_ecocomDP.R
@@ -1,0 +1,108 @@
+# Reformat NEON Tick data to EcocomDP formatting
+# Authors: Wynne Moss, Melissa Chen, Brendan Hobart, Matt Bitters
+# Date: 2/11/2020
+
+### Script to reformat NEON tick abundances
+# uses the data from script 01_data_tick.R (downloads, cleans, links NEON tick data)
+# follows same basic protocol as Mosquito data (Natalie Robinson) 
+
+#### Load packages ####
+# devtools::install_github("https://github.com/EDIorg/ecocomDP")
+library(ecocomDP)
+library(tidyverse)
+
+#### Read in data ####
+# see script 01 for details
+tick_long <- readRDS("data/tck_longform.Rdata")
+tick_site_env <- readRDS("data/tck_sitexspecies_env.Rdata")
+
+#### Create location table ####
+
+tick_location <- tick_site_env %>%
+  select(namedLocation, decimalLatitude, decimalLongitude, elevation, siteID) %>%
+  distinct() %>%
+  rename(
+    location_id = namedLocation,
+    latitude = decimalLatitude,
+    longitude = decimalLongitude,
+    parent_location_id = siteID
+  )
+# 300 tick plots (matches the env data; each row corresponds to a tick drag plot)
+nrow(tick_location)
+length(unique(tick_location$location_id))
+length(unique(tick_site_env$namedLocation))
+length(unique(tick_site_env$plotID))
+
+#### Create location ancillary table ####
+tick_location_ancillary <- tick_site_env %>%
+  select(namedLocation, domainID, siteID, plotID, plotType, nlcdClass) %>%
+  distinct() %>% pivot_longer(domainID:nlcdClass, names_to = "variable_name", values_to = "value")%>%
+  select(
+    location_ancillary_id = namedLocation,
+    location_id = namedLocation, 
+    variable_name,
+    value)
+length(unique(tick_location_ancillary$location_id)) # 300
+
+
+#### Create taxon table ####
+tick_taxon <- tick_long %>%
+  select(acceptedTaxonID, taxonRank, scientificName) %>%
+  rename(taxon_id = acceptedTaxonID,
+         taxon_rank = taxonRank,
+         taxon_name = scientificName) %>%
+  distinct() 
+
+
+#### Create observation table ####
+# NEON event ID is the sampling bout, not the unique tick drag (~5000 possible levels as of 7/2020)
+# however abundances and remarks are at the drag level
+# the event ID really should be the uid_field rather than the column "eventID" so that it links with ancillary table
+# uid_field *would* be unique to each row if we were only measuring one taxon
+# the fact that we have counts for multiple species/lifestages means that uid_field is repeated and can't serve as the unique observation_id
+
+tick_long %>%
+  select(uid_field, namedLocation, collectDate, Species_LifeStage, acceptedTaxonID, LifeStage, IndividualCount, totalSampledArea) %>%
+  mutate(density = IndividualCount/totalSampledArea, package_id = "DP1.10093.001") %>%
+  mutate(variable_name = paste(LifeStage, "density", sep = "_"), unit = "numberPerMeterSquared") %>%
+  mutate(observation_id = row_number()) %>%
+  select(observation_id, event_id = uid_field, package_id, location_id = namedLocation, observation_datetime = collectDate, 
+         taxon_id = acceptedTaxonID, variable_name, value = density, unit) -> tick_observation_table
+
+tick_observation_table %>% filter(is.na(value))
+# lots of 0s 
+nrow(tick_observation_table) 
+length(unique(tick_long$uid_field))*length(unique(tick_long$Species_LifeStage)) # each row is density for a unique drag x lifestage x species
+
+#### Create observation ancillary table ####  
+tick_site_env %>%
+  select(uid_field, targetTaxaPresent, totalSampledArea, samplingMethod, samplingProtocolVersion, remarks_field, countPending) %>%
+  mutate(observation_ancillary_id = row_number(), totalSampledArea = as.character(totalSampledArea)) %>%
+  pivot_longer(targetTaxaPresent:TickCount_Pending, names_to = "variable_name", values_to = "value") %>%
+  mutate(unit = case_when(variable_name == "totalSampledArea" ~ "squareMeters")) %>%
+  select(observation_ancillary_id, event_id = uid_field, variable_name, value, unit) -> tick_observation_ancillary
+
+#### Create dataset summary table ####
+# not sure yet how to do this? 
+#### Write out data ####
+readr::write_csv(
+  tick_location,
+  'data/tick_table_location.csv')
+
+readr::write_csv(
+  tick_location_ancillary,
+  'data/tick_table_location_ancillary.csv')
+
+readr::write_csv(
+  tick_observation_table,
+  'data/tick_table_observation.csv')
+
+readr::write_csv(
+  tick_observation_ancillary,
+  'data/tick_table_observation_ancillary.csv')
+
+readr::write_csv(
+  tick_taxon,
+  'data/tick_table_taxon.csv')
+
+

--- a/NEON_dev_script/tick_code/data_tick.R
+++ b/NEON_dev_script/tick_code/data_tick.R
@@ -1,0 +1,41 @@
+#' Ticks sampled using drag cloths
+#'
+#' This dataset was derived from [NEON data portal](https://data.neonscience.org) with data product ID 'DP1.10093.001'. Details about this data product can be found at <https://data.neonscience.org/data-products/DP1.10093.001>.
+#'
+#' Here, we:
+#' 1. Cleaned taxonomic data: First, we removed taxonomic samples that had low sample quality (`sampleCondition` != "OK"), or did not have a taxonomy assigned (!is.na(`acceptedTaxonID`)). We then simplified the taxonomic data by creating a `lifeStage` column: this was either Nymph, Larvae, or Adult. Any tick that was sexed (e.g. `sexOrAge` was Male or Female) was assigned to the Adult lifestage. The Nymph or Larvae assignments were taken from the `sexOrAge` column. We dropped the Sex information and summed M and F counts into a total adult count (i.e. we grouped by `sampleID`, `acceptedTaxonID`, and `lifeStage` and summed counts). Finally, we converted the taxonomic data into "wide" format for joining with field data. In the wide format, each column is a unique taxonomicID_lifestage and each row is a sample.
+#' 2. Cleaned the field data: First, we removed field surveys that had logistical issues (`samplingImpractical`!="OK"). We verified that all field surveys where ticks were located also had an associated `sampleID`. 
+#' 3. Merged the field and taxonomic data. Specifically we left-joined the tick field data to tick taxonomy data using the `sampleID`. This retains 0 counts from the field data which will not have a record in the taxonomy table. For any record where no ticks were found in the field (`targetTaxaPresent`=="N"), we assigned 0s to all taxonomicID_lifestage columns.
+#' 4. Fixed count discrepancies between field and lab (note that as of 2019 counts may ONLY come from lab so this may not be necessary in future). The lab count (which was taxon-specific) was used as the source of final counts per species-lifestage. When discrepancies were minor we trusted the lab counts. When discrepancies were larger, we used the following decisions:
+#' 4a. In cases where the field count total was greater than the taxonomic count total AND the discrepancy was in the larval stages, we assumed the lab stopped ID'ing after a certain count. We added the additional, un-ID'd "field" larvae to `IXOSP2_Larva` (the highest taxonomic ID)
+#' 4b. In other cases where field count was greater than the taxonomic count and there were `remarks_field` we assumed the remarks were about lost ticks (a common remark). We assigned any un-identified ticks to IXOSP2.
+#' 4c. Some counts did not match because there were too many samples sent to the lab and the invoice limit was reached. If the taxonomy table contained remarks about "invoice limit" or "billing limit" for a given sample ID, we trusted the field counts and added any difference between field and lab counts to the IXOSP2 column. *Note this was a conservative decision but one could reasonably assume that counts assigned to IXOSP2 would really belong to whatever lower order taxonomy was commonly ID'd for the remaining samples.*.
+#' 4d. Removed any remaining samples where field and lab counts were off by >20 percet and there was no obvious explanation. (<1 percent of total records)
+#' 5. Added a column to designate whether ticks were found in the field but counts and IDs were still pending (`COUNT_PENDING`). This will apply to the most recent data, where taxonomists instead of field surveyors perform the counts. Field surveys where no ticks were found are infilled with 0s in all of the count columns, but counts are still NA for samples where ticks were observed. Users of the dataset should consider filtering the data to just those years where there are no counts pending (instead of just removing NAs, which will bias the data towards low abundances).
+#' 5. Created a long-form dataset and re-formatted data into the ecocomDP formatting. 
+#' 
+#' @note Details of locations (e.g. latitude/longitude coordinates can be found in [neon_locations]).
+#'
+#' @format A data frame (also a tibble) with the following columns:
+#'
+#' - `namedLocation`: Name of the measurement location in the NEON database.
+#' - `siteID`: NEON site code.
+#' - `plotID`: Plot identifier (NEON site code_XXX).
+#' - `collectDate`: Date of the collection event.
+#' - `eventID`: An identifier for the set of information associated with the event, which includes information about the place and time of the event.
+#' - `sampleID`: Identifier for sample.
+#' - `sampleCode`: Barcode of a sample.
+#' - `samplingMethod`: Name or code for the method used to collect or test a sample.
+#' - `totalSampledArea`: Total area sampled (square Meter).
+#' - `targetTaxaPresent`: Indicator of whether the sample contained individuals of the target taxa ('Y' or 'N').
+#' - `remarks_field`: Technician notes; free text comments accompanying the record.
+#' - `taxonID`: Accepted species code, based on one or more sources. This is renamed from the `acceptedTaxonID` column so that column names are consistent across different taxonomic groups.
+#' - `LifeStage`: Life stage of the sample ('Adult', 'Larva', or 'Nymph').
+#' - `IndividualCount`: Number of individuals of the same type.
+#' - `CountPending`: Whether counts are still being processed from taxonomy lab ('Y' or 'N'). Consider filtering to years where all counts are available (CountPending=='Y')
+#' - `taxonRank`: The lowest level taxonomic rank that can be determined for the individual or specimen.
+#' - `scientificName`: Scientific name, associated with the taxonID. This is the name of the lowest level taxonomic rank that can be determined.
+#'
+#' @author Wynne Moss, Melissa Chen, Brendan Hobart, Matt Bitters
+#'
+"data_tick"

--- a/R/map_neon.ecocomdp.10003.001.001.R
+++ b/R/map_neon.ecocomdp.10003.001.001.R
@@ -1,21 +1,13 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Daijiang Li
-#' 
-#' @examples 
-#' \dontrun{
-#'
-#' my_result <- map_neon.ecocomdp.10003.001.001(
-#'   site = c("NIWO","DSNY"),
-#'   startdate = "2016-01",
-#'   enddate = "2018-11")
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve count data for BIRD taxa from neon.data.product.id DP1.10003.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for BIRD
 map_neon.ecocomdp.10003.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10003.001",
   ...){
   # Authors: Daijiang Li, Eric Sokol
@@ -24,19 +16,17 @@ map_neon.ecocomdp.10003.001.001 <- function(
   neon_method_id <- "neon.ecocomdp.10003.001.001"
   
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
-  #Error handling if user provides a value for "package" other than "expanded"
-  if("package" %in% names(dots_updated) && dots_updated$package != "expanded") message(
-    paste0("WARNING: expanded package for ", neon.data.product.id, 
-           " is required to execute this request. Downloading the expanded package"))
   
-  dots_updated[["package"]] <- "expanded"
-  
-  allTabs_bird <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  allTabs_bird <- neon.data.list
 
   
   # allTabs_bird = neonUtilities::loadByProduct(dpID = neon.data.product.id, package = "expanded", ...)
@@ -83,9 +73,10 @@ map_neon.ecocomdp.10003.001.001 <- function(
   
   
   # taxon ----
+  my_dots <- list(...)
   
-  if("token" %in% names(dots_updated)){
-    my_token <- dots_updated$token
+  if("token" %in% names(my_dots)){
+    my_token <- my_dots$token
   }else{
     my_token <- NA
   }

--- a/R/map_neon.ecocomdp.10003.001.001.R
+++ b/R/map_neon.ecocomdp.10003.001.001.R
@@ -137,7 +137,6 @@ map_neon.ecocomdp.10003.001.001 <- function(
   
 
 
-  
   table_observation_ancillary <- ecocomDP:::make_neon_ancillary_observation_table(
     obs_wide = table_observation_wide_all,
     ancillary_var_names = c(
@@ -155,6 +154,10 @@ map_neon.ecocomdp.10003.001.001 <- function(
       "endCloudCoverPercentage",
       "observedHabitat",
       "observedAirTemp",
+      "startCloudCoverPercentage",
+      "endCloudCoverPercentage",
+      "startRH",
+      "endRH",
       "kmPerHourObservedWindSpeed",
       "laboratoryName",
       "samplingProtocolVersion",

--- a/R/map_neon.ecocomdp.10022.001.001.R
+++ b/R/map_neon.ecocomdp.10022.001.001.R
@@ -206,7 +206,7 @@ map_neon.ecocomdp.10022.001.001 <- function(
       variable_name = "abundance",
       value = abundance/trappingDays,
       unit = "count per trap day") %>%
-    distinct()
+    dplyr::distinct()
   
   table_observation <- table_observation_raw %>% 
     dplyr::select(observation_id,

--- a/R/map_neon.ecocomdp.10022.001.001.R
+++ b/R/map_neon.ecocomdp.10022.001.001.R
@@ -1,15 +1,5 @@
 ##############################################################################################
 #' @author Kari Norman \email{kari.norman@berkeley.edu}
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomdp.10022.001.001(
-#'   site = c('ABBY','BARR'),
-#'   startdate = "2019-06",
-#'   enddate = "2019-09")
-#'                                          
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve density data for BEETLE from neon.data.product.id DP1.10022.001 from the NEON data portal and map to the ecocomDP 
 #' 
@@ -17,20 +7,26 @@
 
 
 map_neon.ecocomdp.10022.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10022.001",
   ...){
 
-  
-  #NEON target taxon group is ALGAE
+  #NEON target taxon group is BEETLES
   neon_method_id <- "neon.ecocomdp.10022.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
   
-  # download data
-  beetles_raw <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
+  
+  
+   # get data
+  beetles_raw <- neon.data.list
   
   
   # helper function to calculate mode of a column/vector

--- a/R/map_neon.ecocomdp.10022.001.001.R
+++ b/R/map_neon.ecocomdp.10022.001.001.R
@@ -172,7 +172,7 @@ map_neon.ecocomdp.10022.001.001 <- function(
     dplyr::mutate(identificationSource = ifelse(is.na(scientificName.y), identificationSource, "expert")) %>%
     dplyr::select(-ends_with(".x"), -ends_with(".y")) %>%
     dplyr::group_by(individualID) %>%
-    dplyr::filter(n() == 1 | is.na(individualID)) %>% #remove individuals with more than one ID, retain NA individualID's
+    dplyr::filter(dplyr::n() == 1 | is.na(individualID)) %>% #remove individuals with more than one ID, retain NA individualID's
     dplyr::ungroup()
 
 

--- a/R/map_neon.ecocomdp.10022.001.002.R
+++ b/R/map_neon.ecocomdp.10022.001.002.R
@@ -1,29 +1,14 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Matt Helmus \email{mrhelmus@temple.edu}
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomdp.10022.001.002(
-#'   site= c("NIWO","DSNY"),
-#'   startdate = "2016-01",
-#'   enddate = "2017-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#'   
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve count data for HERPTILE taxa from neon.data.product.id DP1.10022.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for HERPS
 map_neon.ecocomdp.10022.001.002 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10022.001",
-  # chkdata = FALSE, # run the code that checks the data
-  # group_nonherps = TRUE, # run the code that aggregates the non-herps into sampleType:not herp
-  # herps_only = TRUE, # run the code that only gives you the samples with herps
-  # print_summary = FALSE, # print a summary table of the data
   ...){
   
   # authors: Matt Helmus (mrhelmus@temple.edu) repurposed Kari Norman's beetle code
@@ -33,18 +18,19 @@ map_neon.ecocomdp.10022.001.002 <- function(
   #NEON target taxon group is HERPS
   neon_method_id <- "neon.ecocomdp.10022.001.002"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
   
-  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
   
   ### Get the Data
-  bycatch_raw <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
-  
-  
+  bycatch_raw <- neon.data.list
   
   
   ### Wrangle Field Data
@@ -277,9 +263,10 @@ map_neon.ecocomdp.10022.001.002 <- function(
   
   
   # taxon ----
+  my_dots <- list(...)
   
-  if("token" %in% names(dots_updated)){
-    my_token <- dots_updated$token
+  if("token" %in% names(my_dots)){
+    my_token <- my_dots$token
   }else{
     my_token <- NA
   }

--- a/R/map_neon.ecocomdp.10043.001.001.R
+++ b/R/map_neon.ecocomdp.10043.001.001.R
@@ -1,47 +1,34 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Natalie Robinson \email{nrobinson@battelleecology.org}
-#' 
-#' @examples 
-#' \dontrun{
-#'
-#' my_result <- map_neon.ecocomdp.10043.001.001(
-#'   site = c("NIWO","DSNY"),
-#'   startdate = "2016-01",
-#'   enddate = "2018-11")
-#' 
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve density data for MOSQUITO from neon.data.product.id DP1.10043.001 from the NEON data portal and map to the ecocomDP 
 
 ##############################################################################################
 # mapping function for MOSQUITO
 map_neon.ecocomdp.10043.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10043.001",
   ...){
   
   #NEON target taxon group is MOSQUITO
   neon_method_id <- "neon.ecocomdp.10043.001.001"
   
-
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
   
-  #Error handling if user provides a value for "package" other than "expanded"
-  if("package" %in% names(dots_updated) && dots_updated$package != "expanded") message(
-    paste0("WARNING: expanded package for ", neon.data.product.id, 
-           " is required to execute this request. Downloading the expanded package"))
-  
-  
-  dots_updated[["package"]] <- "expanded"
-  
-  mos_allTabs <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
   
-
   # getting data ----  
+  mos_allTabs <- neon.data.list
+  
+  
   # Define important data colums
   cols_oi_trap <- c('collectDate','eventID','namedLocation','sampleID')
   cols_oi_sort <- c('collectDate','sampleID','namedLocation','subsampleID')
@@ -303,16 +290,7 @@ map_neon.ecocomdp.10043.001.001 <- function(
                   value,
                   unit) 
   
-  # table_observation_ancillary_wide <- mos_dat %>% 
-  #   dplyr::select(eventID, sampleID) %>% 
-  #   dplyr::filter(!is.na(sampleID)) %>%
-  #   dplyr::rename(neon_sample_id = sampleID,
-  #          neon_event_id = eventID) %>% 
-  #   dplyr::mutate(event_id = neon_sample_id) %>%
-  #   dplyr::distinct()
   
-  
-
   
   
   table_observation_ancillary <- ecocomDP:::make_neon_ancillary_observation_table(
@@ -344,9 +322,6 @@ map_neon.ecocomdp.10043.001.001 <- function(
     ) %>%
     dplyr::distinct()
       
-  
-
-  
   
   
   # make data summary table ----

--- a/R/map_neon.ecocomdp.10058.001.001.R
+++ b/R/map_neon.ecocomdp.10058.001.001.R
@@ -1,18 +1,6 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Michael Just
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomdp.10058.001.001(
-#'   site= c("NIWO","DSNY"),
-#'   startdate = "2016-01",
-#'   enddate = "2017-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#'   
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve percent cover data for PLANT taxa from neon.data.product.id DP1.10058.001 from the NEON data portal and map to the ecocomDP format
 
@@ -22,22 +10,28 @@
 
 # mapping function for PLANT taxa
 map_neon.ecocomdp.10058.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10058.001",
   ...){
   
   #NEON target taxon group is PLANT
   neon_method_id <- "neon.ecocomdp.10058.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
   
+  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
   
   
   ### Get the Data
-  allTabs_plant <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  allTabs_plant <- neon.data.list
   
   
   

--- a/R/map_neon.ecocomdp.10072.001.001.R
+++ b/R/map_neon.ecocomdp.10072.001.001.R
@@ -1,24 +1,13 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Marta Jarzyna
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomdp.10072.001.001(
-#'   site = c("NIWO","DSNY"),
-#'   startdate = "2016-01",
-#'   enddate = "2017-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#' 
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve count data for SMALL_MAMMAL taxa from neon.data.product.id DP1.10072.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for SMALL_MAMMAL taxa
 map_neon.ecocomdp.10072.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10072.001",
   ...){
   
@@ -32,16 +21,19 @@ map_neon.ecocomdp.10072.001.001 <- function(
   #NEON target taxon group is SMALL_MAMMALS
   neon_method_id <- "neon.ecocomdp.10072.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
+  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
   
   ### Get the Data
-  d <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
-  
-  
+  d <- neon.data.list
   
   
   dat.mam <- dplyr::mutate(d$mam_pertrapnight,
@@ -133,9 +125,10 @@ map_neon.ecocomdp.10072.001.001 <- function(
   
   
   # taxon ----
+  my_dots <- list(...)
   
-  if("token" %in% names(dots_updated)){
-    my_token <- dots_updated$token
+  if("token" %in% names(my_dots)){
+    my_token <- my_dots$token
   }else{
     my_token <- NA
   }

--- a/R/map_neon.ecocomdp.10092.001.001.R
+++ b/R/map_neon.ecocomdp.10092.001.001.R
@@ -2,24 +2,13 @@
 ##############################################################################################
 #' @author Melissa Chen
 #' @author Matt Bitters
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomdp.10092.001.001(
-#'   site = c("ORNL","OSBS"),
-#'   startdate = "2016-01",
-#'   enddate = "2017-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#' 
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve positivity data for TICK_PATHOGEN taxa from neon.data.product.id DP1.10092.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for TICK_PATHOGEN taxa
 map_neon.ecocomdp.10092.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10092.001",
   ...){
   
@@ -31,22 +20,21 @@ map_neon.ecocomdp.10092.001.001 <- function(
   #NEON target taxon group is SMALL_MAMMALS
   neon_method_id <- "neon.ecocomdp.10092.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
-  
-  #Error handling if user provides a value for "package" other than "expanded"
-  if("package" %in% names(dots_updated) && dots_updated$package != "expanded") message(
-    paste0("WARNING: expanded package for ", neon.data.product.id, 
-           " is required to execute this request. Downloading the expanded package"))
-  
-  dots_updated[["package"]] <- "expanded"
   
   
-
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
+  
+  
+  
   ### Get the Data
-  tickpathdat <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  tickpathdat <- neon.data.list
   
   
 

--- a/R/map_neon.ecocomdp.10093.001.001.R
+++ b/R/map_neon.ecocomdp.10093.001.001.R
@@ -2,24 +2,13 @@
 ##############################################################################################
 #' @author Wynne Moss
 #' @author Brendan Hobart
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomdp.10093.001.001(
-#'   site = c("BART","DSNY"),
-#'   startdate = "2016-01",
-#'   enddate = "2017-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#' 
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve count data for TICK taxa from neon.data.product.id DP1.10093.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for TICK taxa
 map_neon.ecocomdp.10093.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.10093.001",
   ...){
   
@@ -32,24 +21,22 @@ map_neon.ecocomdp.10093.001.001 <- function(
   #NEON target taxon group is SMALL_MAMMALS
   neon_method_id <- "neon.ecocomdp.10093.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
   
-  #Error handling if user provides a value for "package" other than "expanded"
-  if("package" %in% names(dots_updated) && dots_updated$package != "expanded") message(
-    paste0("WARNING: expanded package for ", neon.data.product.id, 
-           " is required to execute this request. Downloading the expanded package"))
   
-  dots_updated[["package"]] <- "expanded"
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
+  
+ 
   ### Get the Data
-  Tick_all <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  Tick_all <- neon.data.list
   
-  
-  
-
   
   
   # NOTES ON GENERAL DATA ISSUES #
@@ -718,9 +705,10 @@ map_neon.ecocomdp.10093.001.001 <- function(
   
   
   # taxon ----
+  my_dots <- list(...)
   
-  if("token" %in% names(dots_updated)){
-    my_token <- dots_updated$token
+  if("token" %in% names(my_dots)){
+    my_token <- my_dots$token
   }else{
     my_token <- NA
   }

--- a/R/map_neon.ecocomdp.10093.001.001.R
+++ b/R/map_neon.ecocomdp.10093.001.001.R
@@ -33,26 +33,29 @@ map_neon.ecocomdp.10093.001.001 <- function(
       neon_method_id)
   
   
- 
+  
   ### Get the Data
   Tick_all <- neon.data.list
+  
+  # unlist
+  tck_taxonomyProcessed = Tick_all$tck_taxonomyProcessed
+  tck_fielddata = Tick_all$tck_fielddata
   
   
   
   # NOTES ON GENERAL DATA ISSUES #
   
+  
   # Issue 1: the latency between field (30 days) and lab (300 days) is different
   # In 2019, tick counts were switched over to the lab instead of the field
-  # If the samples aren't processed yet, there will be an NA for all the counts (regardless of whether ticks were present)
-  # Normally if ticks weren't present (targetTaxaPresent == "N") we could feel comfortable assigning all the tick counts a 0 (no ticks)
-  # In this case, doing that would mean that there are 0s when ticks are absent and NAs when ticks are present
-  # Yearly trends would show a bias since there are no counts for all the sites with ticks, and 0s when there aren't ticks
-  # Rather, we should not use those dates until the lab data come in
-  # Would be good to check with NEON whether the 0s for counts are assigned at the same time the lab data come in?
+  # If the samples aren't processed yet, there will be an NA for some or all the counts (regardless of whether ticks were present)
+  # If targetTaxaPresent == "N" we will assign the counts a 0 (there is no lab data pending)
+  # If targetTaxaPresent == "Y" but no associated field record, we will keep counts as NA but define that there are counts pending
+  # Yearly trends may show issues for recent years because ONLY 0s are in. 
   
   # Issue 2: larva counts
   # larvae were not always counted or ID'd in earlier years
-  # requiring larval counts to be non-NA will remove records from earlier years
+  # there are excess larvae counted in the field but not IDd in the lab -- assign these to order level
   
   # Issue 3: discrepancies between field counts and lab counts
   # Often lab counts are less than field because they stop counting at a certain limit
@@ -61,222 +64,58 @@ map_neon.ecocomdp.10093.001.001 <- function(
   # Probably OK to ignore most minor issues, and make best attempt at more major issues
   # Drop remaining records that are confusing
   
-  # CLEAN TICK FIELD DATA #
-  
   #### NAs
   # replace empty characters with NAs instead of ""
-  repl_na <- function(x) ifelse(x == "", NA, x)
+  repl_na <- function(x) ifelse(x=="", NA, x)
   
-  tck_fielddata <- dplyr::mutate_if(Tick_all$tck_fielddata, .predicate = is.character,
-                                   .funs = repl_na) %>% tibble::as_tibble()
   
-  # # check which fields have NAs
-  # dplyr::summarise_all(tck_fielddata, ~sum(is.na(.))) %>% as.data.frame()
-  # 
-  #### Quality Flags
-  # remove samples that had logistical issues
-  # keep only those with NA in samplingImpractical
-  tck_fielddata_filtered <- dplyr::filter(tck_fielddata, is.na(samplingImpractical) |
-                                           samplingImpractical == "OK")
-  
-  #### Remove records with no count data
-  # # first confirm that lots of the records with no count data are recent years
-  # tck_fielddata_filtered %>% dplyr::filter(is.na(adultCount), is.na(nymphCount)) %>%
-  #   dplyr::mutate(year = lubridate::year(collectDate)) %>%
-  #   dplyr::pull(year) %>% table()
-  
-  # filter only records with count data
-  tck_fielddata_filtered = dplyr::filter(tck_fielddata_filtered, !is.na(adultCount),
-                                         !is.na(nymphCount), !is.na(larvaCount))
-  # note that requiring larval counts to be non na will drop some legacy data
-  
-  #### Check correspondence between field and lab
-  # Making the assumption that the user only cares about ID'd ticks and not raw abundances.
-  # If so, only include field records corresponding to the dates with lab data
-  
-  # Get rid of field samples that have no taxonomic info
-  tck_fielddata_filtered = dplyr::filter(
-    tck_fielddata_filtered,
-    sampleID %in% Tick_all$tck_taxonomyProcessed$sampleID |
-                                           is.na(sampleID))
-  
-  # Get rid of the tax samples that have no field data
-  # many of these are legacy samples where larvae weren't counted
-  tck_tax_filtered = dplyr::filter(
-    Tick_all$tck_taxonomyProcessed,
-    sampleID %in% tck_fielddata_filtered$sampleID) %>%
-    tibble::as_tibble()
-  
-  # # double check same sample ID in both datasets
-  # length(unique(na.omit(tck_fielddata_filtered$sampleID)))
-  # length(unique(tck_tax_filtered$sampleID)) # match
-   
-  #### Check other quality control/sample remarks
-  
-  # table(tck_fielddata_filtered$sampleCondition) # none of these are major issues
-  
-  # table(tck_fielddata_filtered$dataQF) # legacy data only
-  
-  # tck_fielddata_filtered %>% dplyr::filter(dataQF == "legacyData") %>%
-  #   dplyr::mutate(year = lubridate::year(collectDate)) %>%
-  #   dplyr::pull(year) %>% table()
-  # from earlier years (keep for now)
-  
-  #### Sample IDs
-  # check that all of the rows WITHOUT a sample ID have no ticks
-  # tck_fielddata_filtered %>% dplyr::filter(is.na(sampleID)) %>%
-  #   dplyr::pull(targetTaxaPresent) %>% table() # true
-  
-  # check that all the rows WITH a sample ID have ticks
-  # tck_fielddata_filtered %>% dplyr::filter(!is.na(sampleID)) %>%
-  #   dplyr::pull(targetTaxaPresent) %>% table() # true
-  
-  # sampleID only assigned when there were ticks present; all missing sample IDs are for drags with no ticks (good)
-  # for now, retain sampling events without ticks
-  
-  # make sure sample IDs are unique
-  # tck_fielddata_filtered %>% group_by(sampleID) %>% summarise(n = n()) %>% filter(n > 1) # yes all unique
-  # sum(duplicated(na.omit(tck_fielddata_filtered$sampleID)))
-  
-  # check that drags with ticks present have a sample ID
-  # tck_fielddata_filtered %>% filter(targetTaxaPresent == "Y" & is.na(sampleID)) # none are missing S.ID
-  
-  #### Check Counts vs. NAs
-  
-  # # make sure samples with ticks present have counts
-  # tck_fielddata_filtered %>% filter(targetTaxaPresent == "Y") %>%
-  #   filter(is.na(adultCount) & is.na(nymphCount) & is.na(larvaCount)) %>% nrow()
-  # 
-  # # are there any 0 counts where there should be > 0?
-  # tck_fielddata_filtered %>% filter(targetTaxaPresent == "Y") %>%
-  #   mutate(totalCount = adultCount + nymphCount + larvaCount) %>%
-  #   filter(totalCount == 0) # no
-  
-  ### Check for other missing count data
-  # list of fields that shouldn't have NAs
-  req_cols <- c("siteID", "plotID", "collectDate", 
-                "adultCount", "nymphCount", "larvaCount")
-  
-  # # all should have no NAs
-  # tck_fielddata_filtered %>% select(req_cols) %>% summarise_all(~sum(is.na(.)))
-  
-  # CLEAN TICK TAXONOMY DATA
+  # CLEAN TICK TAXONOMY DATA #
   
   ### replace "" with NA
   tck_tax_filtered <- dplyr::mutate_if(
-    tck_tax_filtered, 
-    .predicate = is.character,
-    .funs = repl_na) %>%
-    ## only retain lab records that are also in the field dataset
-    dplyr::filter(sampleID %in% tck_fielddata_filtered$sampleID)
+    tck_taxonomyProcessed, .predicate = is.character, .funs = repl_na) %>% 
+    tibble::as_tibble() 
   
-  # ### check sample quality flags
-  # table(tck_tax_filtered$sampleCondition)
+  ### only retain lab records that have associated field data
   
-  # none of these are deal breakers but just keep those deemed OK
-  tck_tax_filtered = dplyr::filter(tck_tax_filtered, sampleCondition == "OK")
+  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, sampleID %in% tck_fielddata$sampleID)  # none lost
   
-  # ### check for NAs in fields
-  # tck_tax_filtered %>% select(everything()) %>%
-  #   summarise_all(~sum(is.na(.))) %>% as.data.frame()
-  
-  ### create a flag for potential lab ID/count issues
-  # table(Tick_all$tck_taxonomyProcessed$remarks)
-  
-  tck_fielddata_filtered$IDflag <- NA
-  
-  # mark sample IDs that have taxonomy issues
-  # these come from remarks indicating that ticks in field were mis-ID'd
-  # useful for correcting counts later
-  tax.issues = Tick_all$tck_taxonomyProcessed %>%
-    dplyr::filter(
-      stringr::str_detect(remarks, "insect|mite|not a tick|NOT A TICK|arachnid|spider")) %>%
-    dplyr::pull(sampleID) %>% unique()
-  
-  # add a flag for these samples in the field dataset
-  tck_fielddata_filtered$IDflag[which(tck_fielddata_filtered$sampleID %in% tax.issues)] <- "ID WRONG"
-  
-  # sample IDs where lab reached limit and stopped counting
-  # will help explain why lab counts < field counts
-  invoice.issues <- Tick_all$tck_taxonomyProcessed %>%
-    dplyr::filter(stringr::str_detect(remarks, "billing limit|invoice limit")) %>%
-    dplyr::pull(sampleID) %>% unique()
-  
-  tck_fielddata_filtered$IDflag[
-    which(tck_fielddata_filtered$sampleID %in% invoice.issues)] <- "INVOICE LIMIT"
+  ### check sample quality flags
+  # retain only samples deemed "OK"
+  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, sampleCondition == "OK")
   
   ### require date and taxon ID
-  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, !is.na(identifiedDate)) %>%
-   dplyr::filter(!is.na(acceptedTaxonID))
+  # samples without id's are not ticks! (n = 3) remove them
+  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, !is.na(acceptedTaxonID))
   
-  # # epithet are all NAs (don't need these columns)
-  # table(tck_tax_filtered$infraspecificEpithet)
+  # require a date (no records are lost)
+  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, !is.na(identifiedDate)) 
   
-  # # qualifier
-  # table(tck_tax_filtered$identificationQualifier)
+  ### sex or age columns
+  # required (no records are lost)
+  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, !is.na(sexOrAge))
   
-  # # legacy data is the only flag (OK)
-  # table(tck_tax_filtered$dataQF)
-  
-  # other remarks: some seem relevant for reconciling field and lab
-  # however it will become onerous to go through these individually as dataset grows
-  # ignore most of these for now
-  # unique(tck_tax_filtered$remarks)
-  
-  # ### check that the IDs all make sense
-  # table(tck_tax_filtered$acceptedTaxonID)
-  # # IXOSPP1 = genus ixodes (Ixodes spp.):
-  # tck_tax_filtered %>% filter(acceptedTaxonID == "IXOSPP1") %>% select(scientificName, taxonRank) %>% head()
-  # # IXOSPP = family ixodidae (Ixodidae spp.):
-  # tck_tax_filtered %>% filter(acceptedTaxonID == "IXOSPP") %>% select(scientificName, taxonRank) %>% head()
-  # IXOSP2 = order ixodes (Ixodida sp.):
-  # tck_tax_filtered %>% filter(acceptedTaxonID == "IXOSP2") %>% select(scientificName, taxonRank) %>% head()
-  # IXOSP = family exodidae (Ixodidae sp.)
-  # tck_tax_filtered %>% filter(acceptedTaxonID == "IXOSP") %>% select(scientificName, taxonRank) %>% head()
-  
-  # table(tck_tax_filtered$taxonRank)
-  # table(tck_tax_filtered$family)
-  
-  # if only ID'd to order, all are IXOSP2:
-  # tck_tax_filtered %>% filter(taxonRank == "order") %>% pull(acceptedTaxonID) %>% table()
-  # if only ID'd to family, either IXOSP or IXOSPP
-  # not sure how to deal with mixed species (e.g. IXOSPP)
-  # tck_tax_filtered %>% filter(taxonRank == "family") %>% pull(acceptedTaxonID) %>% table()
-  # tck_tax_filtered %>% filter(taxonRank == "species") %>% pull(acceptedTaxonID) %>% table()
-  
-  # ### sex or age columns
-  # table(tck_tax_filtered$sexOrAge)
-  # tck_tax_filtered %>% filter(is.na(sexOrAge)) # all have sex or age
-  # tck_tax_filtered %>% filter(individualCount == 0 | is.na(individualCount)) %>% nrow() # all have counts
+  # require counts (no records are lost)
+  tck_tax_filtered <- dplyr::filter(tck_tax_filtered, !is.na(individualCount))
   
   # create a lifestage column so tax counts can be compared to field data
-  tck_tax_filtered <- tck_tax_filtered %>%
-    dplyr::mutate(lifeStage = dplyr::case_when(sexOrAge == "Male" | sexOrAge == "Female" |
-                                   sexOrAge == "Adult" ~ "Adult",
-                                 sexOrAge == "Larva" ~ "Larva",
-                                 sexOrAge == "Nymph" ~ "Nymph"))
-  # sum(is.na(tck_tax_filtered$lifeStage))
-  # this assumes that any ticks that were sexed must be adults (I couldn't confirm this)
+  tck_tax_filtered <- dplyr::mutate(
+    tck_tax_filtered, 
+    lifeStage = dplyr::case_when(
+      sexOrAge == "Male" | 
+        sexOrAge == "Female" | 
+        sexOrAge == "Adult" ~ "Adult",
+      sexOrAge == "Larva" ~ "Larva",
+      sexOrAge == "Nymph" ~ "Nymph")) 
   
-  #  MERGE FIELD AND TAXONOMY DATA #
-  
-  # there are a few options here:
-  # 1) left join tick_field to tick_tax: this will keep all the 0s but requires some wide/long manipulation
-  # 2) left join tick_tax to tick_field: this will only keep the records where ticks were ID'd. could add in 0s afterwards depending on preference
-  
-  # We will left join tick_field to tick_tax, so that 0s are preserved.
-  # Merging will require us to resolve count discrepancies (this may be overkill for those interested in P/A)
-  # For simplicity we will also collapse M/F into all adults (also optional)
-  
-  # first check for dup colnames
-  # intersect(colnames(tck_fielddata_filtered), colnames(tck_tax_filtered))
+  ### rename taxonomy columns distinctly from field data
   
   # rename columns containing data unique to each dataset
-  colnames(tck_fielddata_filtered)[colnames(tck_fielddata_filtered)=="uid"] <- "uid_field"
-  colnames(tck_fielddata_filtered)[colnames(tck_fielddata_filtered)=="sampleCondition"] <- "sampleCondition_field"
-  colnames(tck_fielddata_filtered)[colnames(tck_fielddata_filtered)=="remarks"] <- "remarks_field"
-  colnames(tck_fielddata_filtered)[colnames(tck_fielddata_filtered)=="dataQF"] <- "dataQF_field"
-  colnames(tck_fielddata_filtered)[colnames(tck_fielddata_filtered)=="publicationDate"] <- "publicationDate_field"
+  colnames(tck_fielddata)[colnames(tck_fielddata)=="uid"] <- "uid_field"
+  colnames(tck_fielddata)[colnames(tck_fielddata)=="sampleCondition"] <- "sampleCondition_field"
+  colnames(tck_fielddata)[colnames(tck_fielddata)=="remarks"] <- "remarks_field"
+  colnames(tck_fielddata)[colnames(tck_fielddata)=="dataQF"] <- "dataQF_field"
+  colnames(tck_fielddata)[colnames(tck_fielddata)=="publicationDate"] <- "publicationDate_field"
   
   colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="uid"] <- "uid_tax"
   colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="sampleCondition"] <- "sampleCondition_tax"
@@ -284,346 +123,392 @@ map_neon.ecocomdp.10093.001.001 <- function(
   colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="dataQF"] <- "dataQF_tax"
   colnames(tck_tax_filtered)[colnames(tck_tax_filtered)=="publicationDate"] <- "publicationDate_tax"
   
-  # in order to merge counts with field data we will first combine counts from male/female in the tax data into one adult class
-  # if male/female were really of interest you could skip this (but the table will just be much wider since all will have a M-F option)
+  
+  # merge counts from male/female into one adult class
+  # summing male and female counts (assuming biodiversity analyses won't be sex specific)
   
   tck_tax_wide <- tck_tax_filtered %>% 
     dplyr::group_by(sampleID, acceptedTaxonID, lifeStage) %>%
     dplyr::summarise(individualCount = sum(individualCount, na.rm = TRUE)) %>%
     # now make it wide;  only one row per sample id
-    tidyr::pivot_wider(id_cols = sampleID,  
-                names_from = c(acceptedTaxonID, lifeStage), 
-                values_from = individualCount, values_fill = 0)
+    tidyr::pivot_wider(
+      id_cols = sampleID,  
+      names_from = c(acceptedTaxonID, lifeStage), 
+      values_from = individualCount, values_fill = 0)  %>% 
+    dplyr::ungroup()
   
   # each row is now a unique sample id (e.g. a site x species matrix)
   
-  # sum(duplicated(tck_tax_wide$sampleID)) # none are duplicated
-  # sum(duplicated(na.omit(tck_fielddata_filtered$sampleID)))
-  # length(unique(tck_tax_wide$sampleID))
-   
-  tck_merged <- dplyr::left_join(
-    tck_fielddata_filtered, tck_tax_wide, by = "sampleID")
-  
-  #FIX COUNT DISCREPANCIES BETWEEN FIELD AND LAB #
-  
-  ### clean up 0s
-  # if ticks were not found in the field, counts should be 0
-  taxon.cols <- tck_merged %>% 
-    dplyr::select(
-      dplyr::contains(c("_Nymph", "_Adult" , "_Larva"))) %>% 
-    colnames() # columns containing counts per taxon
   
   
-
+  # CLEAN TICK FIELD DATA #
   
-  for(i in 1:length(taxon.cols)){
-    tck_merged[which(tck_merged$targetTaxaPresent =="N"), which(colnames(tck_merged) == taxon.cols[i])] <- 0
-  }
+  tck_fielddata = dplyr::mutate_if(
+    tck_fielddata, 
+    .predicate = is.character, 
+    .funs = repl_na) 
   
+  #### Quality Flags 
+  # remove samples that had logistical issues
+  # keep only those with NA in samplingImpractical 
+  # this is ~11% as of 2020 (many related to COVID)
   
-
+  tck_fielddata_filtered = dplyr::filter(
+    tck_fielddata, 
+    is.na(samplingImpractical)|samplingImpractical == "OK")
   
-  
-  # ### check for NA
-  # # check for NAs in the count columns
-  # tck_merged %>% select_if(is_numeric)%>% summarise_all(~sum(is.na(.)))
-  
-  # NAs indicate the lab determined no ticks in sample or the associated record was pulled
-  
-  # if there are NAs for counts and an ID flag, most likely the lab did not find ticks and field data should be corrected
-  uid_change <- tck_merged %>% 
-    dplyr::select(uid_field, 
-                  dplyr::all_of(taxon.cols), 
-                  IDflag) %>%
-    dplyr::filter_at(
-      dplyr::vars(taxon.cols), 
-      dplyr::all_vars(is.na(.))) %>%
-    dplyr::filter(!is.na(IDflag)) %>% 
-    dplyr::pull(uid_field)
-  
-  # correct the field data to reflect no ticks
-  tck_merged[which(tck_merged$uid_field == uid_change), "targetTaxaPresent"] <- "N"
-  tck_merged[which(tck_merged$uid_field == uid_change), "adultCount"] <- 0
-  tck_merged[which(tck_merged$uid_field == uid_change), "nymphCount"] <- 0
-  tck_merged[which(tck_merged$uid_field == uid_change), "larvaCount"] <- 0
+  # make sure all record with ticks were assigned a sample ID
+  tck_fielddata_filtered = dplyr::filter(
+    tck_fielddata_filtered, 
+    !(targetTaxaPresent=="Y" & is.na(sampleID))) 
   
   
-
-  
-  for(i in 1:length(taxon.cols)){
-    tck_merged[which(tck_merged$uid_field==uid_change), which(colnames(tck_merged) == taxon.cols[i])] = 0
-  }
+  # MERGE AND RESOLVE COUNTS #
   
   
-
+  #### merge the field and lab data and figure out where counts disagree (pre-2019)
+  # add non-existent columns to eventually put unidentified counts into
+  if(!"IXOSP2_Adult" %in% colnames(tck_tax_wide)) {tck_tax_wide$IXOSP2_Adult <- 0}
+  if(!"IXOSP2_Nymph" %in% colnames(tck_tax_wide)) {tck_tax_wide$IXOSP2_Nymph <- 0}
+  if(!"IXOSP2_Larva" %in% colnames(tck_tax_wide)) {tck_tax_wide$IXOSP2_Larva <- 0}
   
-  
-  
-  #### FIX COUNT 1.1 FLAG DISCREPANCIES ###
-  
-  # first get list of columns for easy summing
-  adult_cols <- tck_merged %>% dplyr::select(dplyr::contains("_Adult")) %>% colnames() 
-  nymph_cols <- tck_merged %>% dplyr::select(dplyr::contains("_Nymph")) %>% colnames()
-  larva_cols <- tck_merged %>% dplyr::select(dplyr::contains("_Larva")) %>% colnames()
-  
-  # sum up lab and field totals
-  tck_merged <- tck_merged %>% 
-    dplyr::mutate(
-      totalAdult_tax = rowSums(.[adult_cols]),
-      totalNymph_tax = rowSums(.[nymph_cols]),
-      totalLarva_tax = rowSums(.[larva_cols]),
-      totalCount_tax = rowSums(.[c(adult_cols, nymph_cols, larva_cols)]),
-      totalCount_field = rowSums(.[c("adultCount", "nymphCount", "larvaCount")])
-    )
-  
-  # get a list of columns with counts for easily viewing dataset (optional)
-  countCols <- tck_merged %>%
-    dplyr::select(
-      dplyr::contains(c("adult", "nymph","larva", 
-                        "total", "Adult",  "Nymph",  
-                        "Larva", "Count"), ignore.case = FALSE)) %>%
-    dplyr::select(-totalSampledArea) %>% 
+  # get a list of columns containing taxonomic counts
+  tax_cols = tck_tax_wide %>% 
+    dplyr::ungroup() %>%  
+    dplyr::select(-sampleID) %>% 
     colnames()
   
-  # create flag column to mark issues with count discrepancies
-  tck_merged <- tck_merged %>% 
-    dplyr::mutate(CountFlag = NA) 
   
-  # flag 1: the total count matches, but the life stage columns don't (error 1)
-  tck_merged$CountFlag[tck_merged$totalCount_field == tck_merged$totalCount_tax] <- 1
+  #### left-join field data to lab data using sample ID
+  tck_merged = tck_fielddata_filtered %>% 
+    dplyr::left_join(tck_tax_wide, by = "sampleID") 
   
-  # no flag:  all the counts match (no flag) -- some of the 1s will now be  0s
-  tck_merged$CountFlag[tck_merged$nymphCount == tck_merged$totalNymph_tax &
-                         tck_merged$adultCount == tck_merged$totalAdult_tax &
-                         tck_merged$larvaCount == tck_merged$totalLarva_tax] <- 0
-  
-  # no flag: no ticks
-  tck_merged$CountFlag[tck_merged$targetTaxaPresent=="N"] <- 0
-  
-  # flag 2: the field total is > than tax total
-  tck_merged$CountFlag[tck_merged$totalCount_field > tck_merged$totalCount_tax] <- 2
-  
-  # flag 3: the field total is < than the tax total
-  tck_merged$CountFlag[tck_merged$totalCount_field < tck_merged$totalCount_tax] <- 3
-  
-  # ### reconcile count discrepancies
-  # table(tck_merged$CountFlag)
-  # # the vast majority of counts match.
+  # add in the lab taxonomy remarks
+  tck_merged = tck_tax_filtered %>% 
+    dplyr::filter(!is.na(dataQF_tax)) %>% 
+    dplyr::group_by(sampleID) %>% 
+    dplyr::summarise(
+      dataQF_tax = paste0(dataQF_tax, collapse = " "), 
+      remarks_tax = paste0(remarks_tax, collapse = " ")) %>% 
+    dplyr::select(sampleID, dataQF_tax, remarks_tax) %>% 
+    dplyr::ungroup() %>% 
+    dplyr::right_join(tck_merged) 
   
   
-  #### FIX COUNT 2.1 RECONCILE DISCREPANCIES WHERE TOTALS MATCH ###
-  
-  # ### Flag Type 1: the total count from field and lab matches but not individual lifestages
-  # tck_merged %>% filter(CountFlag == 1) %>% select(all_of(countCols))
-  # # many of these are adults misidentified as nymphs or vice versa
-  # # trust the lab counts here (ignore nymphCount, adultCount, larvaCount from field data)
-  # # don't correct any counts and change the flag from a 1 to 0
-  tck_merged <- tck_merged %>%  
-    dplyr::mutate(CountFlag = ifelse(CountFlag == 1, 0, CountFlag))
-  # table(tck_merged$CountFlag)
+  #### fill in 0s
+  # if target taxa are not present, fill counts as 0s
+  for(i in 1:length(tax_cols)){
+    tck_merged[
+      which(tck_merged$targetTaxaPresent =="N"), 
+      which(colnames(tck_merged) == tax_cols[i])] <- 0
+  } # this will fill in recent years data too
   
   
-  #### FIX COUNT 2.2 RECONCILE DISCREPANCIES WHERE FIELD COUNT > TAX COUNT ###
-  
-  
-  ### Flag Type 2:more ticks found in the field than in the lab
-  
-  # in some cases, there were too many larvae and not all were ID'd
-  # in other cases, there may be issues with the counts and some ended up not being ticks
-  # if we can't rectify, lump the excess field ticks into IXOSP2
-  # IXOSP2 is the least informative ID, essentially the same as marking them as "unidentified tick"
-  
-  ### some of these have notes in the ID flag column indicating a non-tick
-  # trust the lab count and don't correct the counts
-  # remove flag (2->0)
+  ### get totals from the lab for comparisons to field counts
   tck_merged <- tck_merged %>% 
     dplyr::mutate(
-      CountFlag = dplyr::case_when(
-        CountFlag == 2 & IDflag == "ID WRONG" ~ 0,
-        TRUE ~ CountFlag))
-  
-  ### some have more larvae in the field than in the lab
-  # larvae weren't always identified/counted in the lab, or if they were, only counted up to a limit
-  # if there were more larvae in the field than in lab, the extra larvae should be added to the order level (IXOSP2)
-  # "extra larvae" = larvae not counted - those moved to another lifestage
+      Total_Lab_Adult = rowSums(dplyr::across(contains("_Adult"))),
+      Total_Lab_Nymph = rowSums(dplyr::across(contains("_Nymph"))),
+      Total_Lab_Larva = rowSums(dplyr::across(contains("_Larva")))) 
   
   
-
-  if(!"IXOSP2_Larva" %in% names(tck_merged)) tck_merged[,"IXOSP2_Larva"] <- NA_real_
+  ###### get rid of/fix data with missing info 
+  # 2014 and 2015 have some missing field larvae count 
+  # filter to samples where there is no field larvae count but there is a lab larvae count
+  field_larvae_na = dplyr::filter(tck_merged, targetTaxaPresent=="Y") %>% 
+    dplyr::filter(is.na(larvaCount), !is.na(Total_Lab_Larva)) %>% 
+    dplyr::mutate(year = lubridate::year(collectDate)) %>% 
+    dplyr::filter(year<2019) %>% 
+    dplyr::filter(!is.na(adultCount), !is.na(nymphCount)) %>% 
+    dplyr::pull(sampleID) 
+  
+  
+  # replace the field larvae counts with the lab larvae count (not really necessary as we will be using the field data anyways)
+  tck_merged$larvaCount[which(tck_merged$sampleID%in%field_larvae_na)] <- tck_merged$Total_Lab_Larva[which(tck_merged$sampleID%in%field_larvae_na)]
+  
+  
+  # check for other samples where there are missing counts prior to 2019 
+  # drop those records
+  # filter to samples where there is a NA in one of the field counts and it is prior to 2019
+  # these are mostly legacy data and are not very abundant
+  no_counts <- dplyr::filter(tck_merged, targetTaxaPresent=="Y") %>% 
+    dplyr::filter(is.na(adultCount)|is.na(larvaCount)|is.na(nymphCount)) %>% 
+    dplyr::mutate(year = lubridate::year(collectDate)) %>% 
+    dplyr::filter(year<2019) %>% dplyr::pull(sampleID) 
+  
+  tck_merged <- dplyr::filter(tck_merged, !sampleID %in% no_counts)
+  
+  rm(field_larvae_na, no_counts)
+  
+  
+  #### get summed lab vs. field counts for comparisons ####
+  tck_merged <- tck_merged %>% 
+    dplyr::rowwise() %>% 
+    dplyr::mutate(
+      totalFieldCount = sum(adultCount, larvaCount, nymphCount), # calculate total tick count from field data
+      totalLabCount = sum(Total_Lab_Adult, Total_Lab_Nymph, Total_Lab_Larva)) %>%  # calculate total tick count from lab data
+    dplyr::ungroup()
+  
+  
+  # check for field data that don't have associated lab data 
+  # e.g. there is a field count but no taxonomy
+  # these should be removed as we don't know the species
+  missing_lab <- dplyr::filter(
+    tck_merged, !is.na(totalFieldCount) & is.na(totalLabCount)) %>% 
+    dplyr::pull(sampleID) 
+  
+  tck_merged <- dplyr::filter(tck_merged, !(!is.na(sampleID) & sampleID %in% missing_lab)) 
+  
+  rm(missing_lab)
+  
+  
+  # FIX COUNT DISCREPANCIES 
+  
+  # first flag where we have discrepancies in count that we need to fix
+  tck_merged <- tck_merged %>% 
+    dplyr::mutate(
+      Discrepancy = dplyr::case_when(
+        is.na(adultCount) & is.na(nymphCount) & 
+          is.na(larvaCount) & targetTaxaPresent=="Y" & 
+          !is.na(totalLabCount) ~"LAB COUNT ONLY", # no field counts but lab counts exist (2019 onwards)
+        (is.na(adultCount) | is.na(nymphCount) | is.na(larvaCount)) & 
+          targetTaxaPresent=="Y" & 
+          lubridate::year(collectDate)>2018 ~"COUNT PENDING", # still waiting on lab counts
+        totalFieldCount==0 & totalLabCount == 0 ~ "NONE", # no ticks; no discrepancy
+        totalFieldCount >0 & totalLabCount > 0 & totalFieldCount==totalLabCount~"NONE",  # matching counts; no discrepancy
+        targetTaxaPresent=="N"~"NONE", # no ticks; no discrepancy
+        totalFieldCount > totalLabCount ~ "FIELD COUNT GREATER",
+        totalFieldCount < totalLabCount ~ "LAB COUNT GREATER"
+      )) 
+  
+  
+  
+  ## FIX COUNTS 1: ONLY A SUBSET OF LARVAE WERE SAMPLED/COUNTED
+  
+  # if there are more larvae in the field than lab and a quality flag add the remaining larvae to unidentified order
+  
+  add_unknown_larvae <- tck_merged %>% 
+    dplyr::filter(dataQF_tax == "ID lab count subsample of total field larvae") %>% # flag indicating the lab didn't count all larvae
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% # larvae in the field > larvae in lab
+    dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in larvae is equal to the entire discrepancy
+    dplyr::pull(sampleID)  # if so, pull those sample IDs
+  
+  tck_merged <- tck_merged %>% 
+    dplyr::mutate(
+      IXOSP2_Larva = dplyr::case_when( 
+        sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy in larvae to the order level (IXOSP2_Larva)
+        TRUE ~ IXOSP2_Larva
+      ))  
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] <- "FIXED" # remove the flag
+  rm(add_unknown_larvae)
+  
+  # if there are more larvae in the field than lab and there is a note about invoicing, add remaining larvae
+  add_unknown_larvae <- tck_merged %>% 
+    dplyr::filter(stringr::str_detect(remarks_tax, "invoice")) %>% # flag that the lab reached an invoicing limit
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>%
+    dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in larvae is equal to the entire discrepancy
+    dplyr::pull(sampleID)  # if so pull those sample IDs
+  
+  tck_merged <- tck_merged %>% 
+    dplyr::mutate(IXOSP2_Larva = dplyr::case_when(
+      sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+      TRUE~IXOSP2_Larva)) 
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] <- "FIXED" # remove the flag
+  rm(add_unknown_larvae)
+  
+  # another indicator that not all the larvae were counted
+  add_unknown_larvae <- tck_merged %>% 
+    dplyr::filter(stringr::str_detect(remarks_tax, "possibly subsampled in ID lab counts")) %>%  # flag indicating the lab didn't count all larvae
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>%
+    dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in larvae is equal to the entire discrepancy
+    dplyr::pull(sampleID)  # if so pull those sample IDs
   
   tck_merged <- tck_merged %>% 
     dplyr::mutate(
       IXOSP2_Larva = dplyr::case_when(
-        CountFlag == 2 & larvaCount > totalLarva_tax & is.na(IDflag) ~ 
-          IXOSP2_Larva + 
-          (larvaCount - totalLarva_tax) + 
-          (nymphCount - totalNymph_tax) + 
-          (larvaCount - totalLarva_tax),
-    TRUE ~ IXOSP2_Larva))
+        sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+        TRUE~IXOSP2_Larva)) 
   
-  # remove flag
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] <- "FIXED"
+  rm(add_unknown_larvae)
+  
+  ## do the same for nymphs
+  add_unknown_nymph <- tck_merged %>% 
+    dplyr::filter(
+      stringr::str_detect(remarks_tax, "possibly subsampled in ID lab counts")) %>%  # flag indicating the lab didn't count all larvae
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>%
+    dplyr::filter((nymphCount - Total_Lab_Nymph)==(totalFieldCount-totalLabCount)) %>%  # if the discrepancy in nymphs is equal to the entire discrepancy
+    dplyr::pull(sampleID) 
+  
   tck_merged <- tck_merged %>% 
     dplyr::mutate(
-      CountFlag = dplyr::case_when(
-        CountFlag == 2 & larvaCount>totalLarva_tax & is.na(IDflag)~0,
-        TRUE ~ CountFlag)) 
+      IXOSP2_Nymph= dplyr::case_when(
+        sampleID %in% add_unknown_nymph ~ IXOSP2_Nymph + totalFieldCount - totalLabCount, # add discrepancy to the order level
+        TRUE~IXOSP2_Nymph)) 
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_nymph] <- "FIXED"
+  rm(add_unknown_nymph)
   
   
-  ### some counts are off by only a few individuals (negligible)
-  # could be miscounted in the field or lost in transit
-  # if counts are off by < 10% this difference is not too meaningful
-  # trust the lab count data, don't change any counts
-  # remove flag
+  
+  ##  FIX COUNTS 2: LARVA COUNT RECORDED AS 1  
+  # NEON working on fixing this one
+  # in some years, the lab accidentally put larvae as 1 but the field count says it should be higher
+  add_unknown_larvae <- tck_merged %>% 
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% 
+    dplyr::filter(stringr::str_detect(dataQF_tax, "field larva count higher")) %>% 
+    dplyr::filter(lubridate::year(collectDate) %in% c(2016, 2017)) %>% 
+    dplyr::filter(Total_Lab_Larva==1) %>%   # flag indicating the lab assigned all as a 1 
+    dplyr::filter((larvaCount - Total_Lab_Larva)==(totalFieldCount-totalLabCount)) %>% 
+    dplyr::pull(sampleID) 
+  
+  tck_merged = tck_merged %>% 
+    dplyr::mutate(
+      IXOSP2_Larva = dplyr::case_when(
+        sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+        TRUE~IXOSP2_Larva)) 
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] <- "FIXED"
+  rm(add_unknown_larvae)
+  
+  add_unknown_larvae <- tck_merged %>% 
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% 
+    dplyr::filter(dataQF_field == "field larva count higher than ID lab (PDE >25%)") %>% 
+    dplyr::filter(Total_Lab_Larva == 1) %>% 
+    dplyr::pull(sampleID)
+  
   tck_merged <- tck_merged %>% 
     dplyr::mutate(
-      CountFlag = dplyr::case_when(
-        CountFlag == 2 & (totalCount_field - totalCount_tax)/totalCount_field < 0.1 ~0, # if discrepancy < 10% of total
-        TRUE ~ CountFlag))
+      IXOSP2_Larva = dplyr::case_when(
+        sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+        TRUE~IXOSP2_Larva)) 
   
-  ### some counts are off by more than 10% but explanation is obvious
-  # cases where 1-2 field ticks are "missing" but discrepancy is more than 10% of total count
-  # if there are field remarks, assume they are about ticks being lost (see field_remarks output)
-  # assign missing field ticks to order level IXOSP2
-  # missing (unidentified) ticks = missing counts that were not assigned to other lifestages
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] <- "FIXED"
+  rm(add_unknown_larvae)
   
-  # if IXOSP2 doesn't exist for other lifestages, add it
-  if(sum(colnames(tck_merged) == "IXOSP2_Adult")==0) {
-    # if column doesn't exist,
-    # add it with a default of 0
-    tck_merged <- tck_merged %>% 
-      dplyr::mutate(IXOSP2_Adult = 0)
-  }
-  if (sum(colnames(tck_merged) == "IXOSP2_Nymph") == 0) {
-    tck_merged <- tck_merged %>% 
-      dplyr::mutate(IXOSP2_Nymph = 0)
-  }
-  if (sum(colnames(tck_merged) == "IXOSP2_Larva") == 0) {
-    tck_merged <- tck_merged %>% 
-      dplyr::mutate(IXOSP2_Larva = 0)
-  }
   
-  # if there are missing adults and remarks in the field, add the missing adults to IXOSP2_Adult
+  
+  ## FIX COUNTS 3: ADULTS WENT MISSING 
+  add_unknown_adult <- tck_merged %>% 
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER") %>% 
+    dplyr::filter(dataQF_field == "field adult count higher than ID lab (PDE >25%)") %>%  # a few missing adults
+    dplyr::pull(sampleID) 
+  
   tck_merged <- tck_merged %>% 
     dplyr::mutate(
       IXOSP2_Adult = dplyr::case_when(
-        CountFlag == 2 & adultCount>totalAdult_tax & 
-          (adultCount-totalAdult_tax) <= 2 & !is.na(remarks_field) ~
-          IXOSP2_Adult+ (adultCount - totalAdult_tax) + 
-          (nymphCount-totalNymph_tax) + (larvaCount-totalLarva_tax), # count discrepancy add to order IXOSP2
-        TRUE ~ IXOSP2_Adult)) %>%
-    # if there are missing nymphs and remarks in the field, add the missing adults to IXOSP2_Nymph
-    dplyr::mutate(
-      IXOSP2_Nymph = dplyr::case_when(
-        CountFlag == 2 & nymphCount>totalNymph_tax & 
-          (nymphCount-totalNymph_tax) <= 2 & !is.na(remarks_field) ~
-          IXOSP2_Nymph+ (adultCount - totalAdult_tax) + 
-          (nymphCount-totalNymph_tax) + (larvaCount-totalLarva_tax), # count discrepancy add to order IXOSP2
-        TRUE ~ IXOSP2_Nymph)) %>%
-    # if there are missing larvae and remarks in the field, add the missing adults to IXOSP2_Larva
+        sampleID %in% add_unknown_adult ~ IXOSP2_Adult + totalFieldCount - totalLabCount, # add discrepancy to the order level
+        TRUE~IXOSP2_Adult)) 
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_adult] <- "FIXED"
+  rm(add_unknown_adult)
+  
+  
+  ## FIX COUNTS 4: IGNORE MINOR DISCREPANCIES
+  # if the difference is small, we will use the taxonomy data and ignore the discrepancy 
+  
+  # less than 5 individuals
+  minor_discrep = tck_merged %>% 
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER", totalFieldCount-totalLabCount<5) %>%
+    dplyr::pull(sampleID)   # get records where the differences < 5 ticks
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% minor_discrep] <- "MINOR"
+  rm(minor_discrep)
+  
+  # less than 10%
+  minor_discrep <- tck_merged %>% 
+    dplyr::filter(
+      Discrepancy == "FIELD COUNT GREATER", 
+      (totalFieldCount-totalLabCount)/totalFieldCount<.1) %>%
+    dplyr::pull(sampleID)  # records where the difference is <10%
+  
+  tck_merged$Discrepancy[tck_merged$sampleID %in% minor_discrep] <- "MINOR"
+  rm(minor_discrep)
+  
+  
+  ## FIX COUNTS 6: MORE THAN ONE ERROR 
+  # wrong lifestage ID and wrong counts... 
+  
+  # more than 500 larvae -- the lab will not count all of them
+  add_unknown_larvae <- tck_merged %>% 
+    dplyr::filter(Discrepancy == "FIELD COUNT GREATER", 
+                  larvaCount>Total_Lab_Larva, larvaCount>500) %>% 
+    dplyr::pull(sampleID) 
+  
+  tck_merged <- tck_merged %>% 
     dplyr::mutate(
       IXOSP2_Larva = dplyr::case_when(
-        CountFlag == 2 & larvaCount>totalLarva_tax & 
-          (larvaCount-totalLarva_tax) <= 2 & !is.na(remarks_field) ~
-          IXOSP2_Larva + (adultCount - totalAdult_tax) + 
-          (nymphCount-totalNymph_tax) + (larvaCount-totalLarva_tax),
-      TRUE ~ IXOSP2_Larva))
+        sampleID %in% add_unknown_larvae ~ IXOSP2_Larva + totalFieldCount - totalLabCount, # add discrepancy to the order level
+        TRUE~IXOSP2_Larva))
   
+  tck_merged$Discrepancy[tck_merged$sampleID %in% add_unknown_larvae] <- "FIXED"
+  rm(add_unknown_larvae)
   
-  # remove flag
-  tck_merged <- tck_merged %>% 
-    dplyr::mutate(
-      CountFlag = dplyr::case_when(
-        CountFlag == 2 & adultCount>totalAdult_tax & 
-          (adultCount-totalAdult_tax) <= 2 & !is.na(remarks_field) ~ 0,
-        CountFlag == 2 & nymphCount>totalNymph_tax & 
-          (nymphCount-totalNymph_tax) <=2 & !is.na(remarks_field) ~ 0,
-        CountFlag == 2 & larvaCount>totalLarva_tax & 
-          (larvaCount-totalLarva_tax) <=2 & !is.na(remarks_field) ~ 0,
-        TRUE~ CountFlag))
+  ## GET RID OF ANY UNSOLVED MYSTERIES 
   
-  
-  ### some counts are off because over invoice limit
-  # in this case trust the field counts, and extra are assigned to order level
-  tck_merged <- tck_merged %>% 
-    dplyr::mutate(
-      IXOSP2_Nymph = dplyr::case_when(
-        CountFlag == 2 & nymphCount > totalNymph_tax & IDflag == "INVOICE LIMIT" ~
-          IXOSP2_Nymph+ (adultCount - totalAdult_tax) + 
-          (nymphCount-totalNymph_tax) + (larvaCount-totalLarva_tax), # add count discrepancy to order
-        TRUE ~ IXOSP2_Nymph)) %>%
-    dplyr::mutate(
-      IXOSP2_Larva = dplyr::case_when(
-        CountFlag == 2 & larvaCount>totalLarva_tax & IDflag == "INVOICE LIMIT" ~
-          IXOSP2_Larva+ (adultCount - totalAdult_tax) + 
-          (nymphCount-totalNymph_tax) + (larvaCount-totalLarva_tax), # add count discrepancy to order
-        TRUE ~ IXOSP2_Larva)) %>%
-    dplyr::mutate(
-      IXOSP2_Adult = dplyr::case_when(
-        CountFlag == 2 & adultCount>totalAdult_tax & IDflag == "INVOICE LIMIT" ~
-          IXOSP2_Adult+ (adultCount - totalAdult_tax) + 
-          (nymphCount-totalNymph_tax) + (larvaCount-totalLarva_tax), # add count discrepancy to order
-        TRUE ~ IXOSP2_Adult))
-  
-  # remove flag
-  tck_merged <- tck_merged %>% 
-    dplyr::mutate(
-      CountFlag = dplyr::case_when(
-    CountFlag == 2 & adultCount>totalAdult_tax &IDflag == "INVOICE LIMIT" ~ 0,
-    CountFlag == 2 & nymphCount>totalNymph_tax &IDflag == "INVOICE LIMIT" ~ 0,
-    CountFlag == 2 & larvaCount>totalLarva_tax &IDflag == "INVOICE LIMIT" ~ 0,
-    TRUE ~ CountFlag))
-  
-  #### FIX COUNT 2.3 RECONCILE DISCREPANCIES WHERE FIELD COUNT < TAX COUNT
-  
-  ### cases where counts are off by minor numbers
-  # this could be miscounts in the field
-  # if the discrepancy is less than 30% of the total count or 5 or less individuals
-  # trust the lab count here and don't correct counts
-  
-  # remove flag
-  tck_merged <- tck_merged %>% dplyr::mutate(
-    CountFlag = dplyr::case_when(
-      CountFlag == 3 & (abs(totalCount_tax-totalCount_field))/totalCount_tax < 0.3 ~ 0,
-      (totalCount_tax - totalCount_field)<=5 ~ 0,
-      TRUE ~ CountFlag))
-  
-  #### FIX COUNT 2.4 REMOVE THE UNSOLVED MYSTERY SAMPLES
-  # cases with larger discrepancies that aren't obvious are removed from final dataset
-  # make sure this is less than 1% of total cases
-  # more work could be done here if there are many cases in this category
-  if((tck_merged %>% dplyr::filter(CountFlag!=0) %>% nrow())/nrow(tck_merged)< 0.01){
-    tck_merged <- tck_merged %>% dplyr::filter(CountFlag==0)
+  # if less than 1 percent of records are unresolved, get rid of them
+  if((tck_merged %>% 
+      dplyr::filter(Discrepancy =="FIELD COUNT GREATER") %>% 
+      nrow())/nrow(tck_merged) < 0.05){
+    
+    tck_merged <- tck_merged %>% 
+      dplyr::filter(Discrepancy !="FIELD COUNT GREATER") 
   }
+  
+  # table(tck_merged$Discrepancy)
+  
+  #### OTHER Q/C STEPS 
+  # add a column to designate samples for which counts have not been assigned yet
+  # this is for recent data where the field info is published but no associated lab data
+  tck_merged <- tck_merged  %>% 
+    dplyr::mutate(
+      COUNT_PENDING = dplyr::case_when(
+        targetTaxaPresent == "Y" & 
+          (is.na(adultCount) | is.na(larvaCount) | is.na(nymphCount)) & 
+          is.na(totalLabCount)~"Y",
+        !is.na(totalLabCount)~"N")) 
+  
   
   #### Final notes on count data
   # note that some of these could have a "most likely" ID assigned based on what the majority of IDs are
-  # for now don't attempt to assign.
+  # for now don't attempt to assign. 
   # the user can decide what to do with the IXOSP2 later (e.g. assign to lower taxonomy)
   # from this point on, trust lab rather than field counts because lab were corrected if discrepancy exists
+  rm(repl_na, tax_cols)
+  
   
   # RESHAPE FINAL DATASET
+  
   
   # will depend on the end user but creating two options
   # note that for calculation of things like richness, might want to be aware of the level of taxonomic resolution
   
   taxon.cols <- tck_merged %>% 
-    dplyr::select(
-      dplyr::contains(c("_Larva", "_Nymph", "_Adult"))) %>% 
-    colnames() # columns containing counts per taxon
+    dplyr::select(-contains("Total")) %>% 
+    dplyr::select(contains(c("_Larva", "_Nymph", "_Adult"))) %>% 
+    colnames()   # columns containing counts per taxon
   
   
   ### option 1) long form data including 0s
   
   # get rid of excess columns (user discretion)
   tck_merged_final <- tck_merged %>% 
-    dplyr::select(
-      -CountFlag, -IDflag, -totalAdult_tax, -totalNymph_tax, 
-      -totalLarva_tax, -totalCount_tax, -totalCount_field,
-      -nymphCount, -larvaCount, -adultCount,
-      -samplingImpractical, -measuredBy, -dataQF_field)
-  
-  
+    dplyr::select(-Discrepancy, -totalLabCount, 
+                  -totalFieldCount, -Total_Lab_Adult, -Total_Lab_Larva, 
+                  -Total_Lab_Nymph,
+                  # -publicationDate_field, 
+                  -measuredBy, 
+                  -larvaCount, -nymphCount, -adultCount,
+                  -coordinateUncertainty, -elevationUncertainty,
+                  -samplingImpractical, -dataQF_field, 
+                  # -remarks_field, 
+                  # -remarks_tax
+                  ) %>% 
+    dplyr::rename(countPending = COUNT_PENDING)
   # long form data
+  
   tck_merged_final <- tck_merged_final %>% 
     tidyr::pivot_longer(
       cols = all_of(taxon.cols), 
@@ -632,54 +517,24 @@ map_neon.ecocomdp.10093.001.001 <- function(
     tidyr::separate(
       Species_LifeStage, 
       into = c("acceptedTaxonID", "LifeStage"), 
-      sep = "_", 
-      remove = FALSE)
+      sep = "_", remove = FALSE) 
   
+  # add in taxonomic resolution
   
-  # # add in taxonomic resolution
-  # table(Tick_all$tck_taxonomyProcessed$acceptedTaxonID, Tick_all$tck_taxonomyProcessed$taxonRank)# accepted TaxonID is either at family, order, or species level
-  # table(Tick_all$tck_taxonomyProcessed$acceptedTaxonID, Tick_all$tck_taxonomyProcessed$scientificName)
-  
-  
-  tax_rank <- Tick_all$tck_taxonomyProcessed %>% 
+  tax_rank <- tck_taxonomyProcessed %>% 
     dplyr::group_by(acceptedTaxonID) %>% 
     dplyr::summarise(
-      taxonRank =  dplyr::first(taxonRank), 
-      scientificName = dplyr::first(scientificName))
+      taxonRank = dplyr::first(taxonRank), 
+      scientificName = dplyr::first(scientificName)) 
   
   tck_merged_final <- tck_merged_final %>% 
-    dplyr::left_join(tax_rank, by = "acceptedTaxonID")
+    dplyr::left_join(tax_rank, by = "acceptedTaxonID") 
   
-  # setdiff(tck_merged_final$acceptedTaxonID, tck_tax_filtered$acceptedTaxonID)
   
-  data_tick <- tck_merged_final %>% 
-    dplyr::filter(
-      sampleCondition_field == "No known compromise") %>%
-    dplyr::select(
-      # -uid_field, 
-      -sampleCondition_field, 
-      -samplingProtocolVersion, -Species_LifeStage) %>%
-    unique() %>%
-    dplyr::left_join(
-      dplyr::select(
-        tck_tax_filtered, acceptedTaxonID, family, identificationReferences) %>%
-        dplyr::distinct() %>%
-        dplyr::group_by(acceptedTaxonID) %>%
-        dplyr::summarise(
-          family = unique(family)[1],
-          identificationReferences = paste(unique(identificationReferences),
-                                           collapse = "; "), .groups = "drop") %>%
-        dplyr::distinct(),
-      by = "acceptedTaxonID") %>%
-    dplyr::rename(taxonID = acceptedTaxonID,
-                  publicationDate = publicationDate_field)
-  # NOTES FOR END USERS  #
-  # be aware of higher order taxa ID -- they are individuals ASSIGNED at a higher taxonomic class, rather than the sum of lower tax. class
-  # higher order taxonomic assignments could be semi-identified by looking at most likely ID (e.g. if 200 of 700 larvae are IXOSPAC, very likely that the Unidentified larvae are IXOSPAC)
-  # unidentified could be changed to IXOSPP across the board
-  # All combos of species-lifestage aren't in the long form (e.g. if there were never IXOAFF_Adult, it will be missing instead of 0)
-  
-
+  # flat data to map to ecocomDP
+  data_tick <- tck_merged_final %>%
+    dplyr::rename(
+      taxonID = acceptedTaxonID)
   
   
   #location ----
@@ -775,8 +630,6 @@ map_neon.ecocomdp.10093.001.001 <- function(
   
   
   
-
-  
   
   table_observation_ancillary <- ecocomDP:::make_neon_ancillary_observation_table(
     obs_wide = table_observation_all,
@@ -792,7 +645,10 @@ map_neon.ecocomdp.10093.001.001 <- function(
       "identificationReferences",
       "release",
       "publicationDate"
-      ))
+    )) %>%
+    dplyr::mutate(
+      unit = dplyr::case_when(
+        variable_name == "totalSampledArea" ~ "square meter"))
   
   # data summary ----
   # make dataset_summary -- required table

--- a/R/map_neon.ecocomdp.20107.001.001.R
+++ b/R/map_neon.ecocomdp.20107.001.001.R
@@ -1,22 +1,13 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Thilina Surasinghe \email{tsurasinghe@bridgew.edu}
-#' 
-#' @examples 
-#' \dontrun{
-#' my_result <- map_neon.ecocomdp.20107.001.001(
-#'   site = c(c('COMO','LECO')),
-#'   startdate = "2016-01",
-#'   enddate = "2018-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve count data for FISH taxa from neon.data.product.id DP1.20107.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for FISH
 map_neon.ecocomdp.20107.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.20107.001",
   ...){
   # Authors: Stephanie Parker, Thilina Surasinghe (sparker@battelleecology.org, tsurasinghe@bridgew.edu), Eric Sokol (esokol@battelleecology.org)
@@ -27,12 +18,23 @@ map_neon.ecocomdp.20107.001.001 <- function(
   #NEON target taxon group is FISH
   neon_method_id <- "neon.ecocomdp.20107.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
+  
+  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
+  
   
   # get token from dots if available
-  if("token" %in% names(dots_updated)){
-    my_token <- dots_updated$token
+  my_dots <- list(...)
+  
+  if("token" %in% names(my_dots)){
+    my_token <- my_dots$token
   }else{
     my_token <- NA
   }
@@ -55,17 +57,9 @@ map_neon.ecocomdp.20107.001.001 <- function(
   
   
   
-  #Error handling if user provides a value for "package" other than "expanded"
-  if("package" %in% names(dots_updated) && dots_updated$package != "expanded") message(
-    paste0("WARNING: expanded package for ", neon.data.product.id, 
-           " is required to execute this request. Downloading the expanded package"))
-  
-  dots_updated[["package"]] <- "expanded"
-  
-  # get data FISH via api -- will take a while --  package = "basic" is also possible
-  all_fish <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+
+  # get data FISH data from NEON api
+  all_fish <- neon.data.list
   
   # The object returned by loadByProduct() is a named list of data frames.
   # To work with each of them, select them from the list using the $ operator.

--- a/R/map_neon.ecocomdp.20120.001.001.R
+++ b/R/map_neon.ecocomdp.20120.001.001.R
@@ -1,14 +1,5 @@
 ##############################################################################################
 #' @author Stephanie Parker \email{sparker@battelleecology.org}
-#' 
-#' @examples 
-#' \dontrun{
-#' 
-#' my_result <- map_neon.ecocomDP.20120.001.001(
-#'   site= c('COMO','LECO'),
-#'   startdate = "2019-06",
-#'   enddate = "2019-09")
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve density data for MACROINVERTEBRATE from neon.data.product.id DP1.20120.001 from the NEON data portal and map to the ecocomDP format
 
@@ -20,16 +11,28 @@
 ##### my version ----
 # updated by Eric on 6/9/2020 ~5:10pm
 map_neon.ecocomdp.20120.001.001 <- function(
+  neon.data.list,
   neon.data.product.id ="DP1.20120.001",
   ...){
   
   #NEON target taxon group is MACROINVERTEBRATE
   neon_method_id <- "neon.ecocomdp.20120.001.001"
  
+  
+  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
+  
+  
+  
   # get all tables for this data product for the specified sites in my_site_list, store them in a list called all_tabs
-  all_tabs <- neonUtilities::loadByProduct(
-    dpID = neon.data.product.id,
-    ...)
+  all_tabs <- neon.data.list
    
   
   # extract the table with the field data from the all_tabs list of tables
@@ -234,10 +237,3 @@ map_neon.ecocomdp.20120.001.001 <- function(
   return(out_list)
   
 } #END of function
-
-# my_result <- map_neon_data_to_ecocomDP.MACROINVERTEBRATE(site= c('COMO','LECO'), startdate = "2019-06",enddate = "2019-09")
-# my_result <- map_neon_data_to_ecocomDP.MACROINVERTEBRATE(site= c('COMO','LECO'),check.size = FALSE)
-# my_result <- map_neon_data_to_ecocomDP(neon.data.product.id = "DP1.20120.001", site= c('COMO','LECO'), check.size = FALSE, token = Sys.getenv("NEON_TOKEN"))
-# my_result <- read_data(id = "DP1.20120.001", site= c('COMO','LECO'), check.size = FALSE, token = Sys.getenv("NEON_TOKEN"))
-
-

--- a/R/map_neon.ecocomdp.20166.001.001.R
+++ b/R/map_neon.ecocomdp.20166.001.001.R
@@ -7,6 +7,7 @@
 #     original creation
 ##############################################################################################
 map_neon.ecocomdp.20166.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.20166.001",
   ...
 ){
@@ -14,10 +15,21 @@ map_neon.ecocomdp.20166.001.001 <- function(
   #NEON target taxon group is ALGAE
   neon_method_id <- "neon.ecocomdp.20166.001.001"
   
+  
+  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
+  
+  
+  
   # get all tables
-  all_tabs_in <- neonUtilities::loadByProduct(
-    dpID = neon.data.product.id, 
-    ...)
+  all_tabs_in <- neon.data.list
   
   
   

--- a/R/map_neon.ecocomdp.20219.001.001.R
+++ b/R/map_neon.ecocomdp.20219.001.001.R
@@ -1,23 +1,13 @@
 ##############################################################################################
 ##############################################################################################
 #' @author Lara Janson
-#' 
-#' @examples 
-#' \dontrun{
-#'
-#' my_result <- map_neon.ecocomdp.20219.001.001(
-#'   site = c("BARC","SUGG"),
-#'   startdate = "2016-01",
-#'   enddate = "2017-11",
-#'   token = Sys.getenv("NEON_TOKEN"),
-#'   check.size = FALSE)
-#' }
 
 #' @describeIn map_neon_data_to_ecocomDP This method will retrieve count data for ZOOPLANKTON taxa from neon.data.product.id DP1.20219.001 from the NEON data portal and map to the ecocomDP format
 
 ##############################################################################################
 # mapping function for ZOOPLANKTON taxa
 map_neon.ecocomdp.20219.001.001 <- function(
+  neon.data.list,
   neon.data.product.id = "DP1.20219.001",
   ...){
   
@@ -26,14 +16,19 @@ map_neon.ecocomdp.20219.001.001 <- function(
   #NEON target taxon group is ZOOPLANKTON
   neon_method_id <- "neon.ecocomdp.20219.001.001"
   
-  # check arguments passed via dots for neonUtilities
-  dots_updated <- list(..., dpID = neon.data.product.id)
+  
+  # make sure neon.data.list matches the method
+  if(!any(grepl(
+    neon.data.product.id %>% gsub("^DP1\\.","",.) %>% gsub("\\.001$","",.), 
+    names(neon.data.list)))) stop(
+      "This dataset does not appeaer to be sourced from NEON ", 
+      neon.data.product.id,
+      " and cannot be mapped using method ", 
+      neon_method_id)
   
   
   ### Get the Data
-  allTabs_zoop <- rlang::exec( 
-    neonUtilities::loadByProduct,
-    !!!dots_updated)
+  allTabs_zoop <- neon.data.list
   
   
 

--- a/R/map_neon_data_to_ecocomDP.r
+++ b/R/map_neon_data_to_ecocomDP.r
@@ -8,8 +8,10 @@
 #' @description
 #' Pull files from the NEON API by data product, merge data for each table, and convert to ecocomDP format. Please see neonUtilities::loadByProduct for more information. 
 #'
-#' @param id (character) Identifier of dataset to read. Identifiers are listed in the "id" column of the \code{search_data()} output. e.g., \code{neon.ecocomdp.20166.001.001} is the data product id for "ALGAE Periphyton, seston, and phytoplankton collection" converted to the ecocomDP format from the NEON source data product DP1.20166.001. 
-#' @param neon.data.product.id (character) The identifier of the NEON data product to pull from the NEON API and map to the ecocomDP format. This argument is specified in each internal mapping function and is NOT provided by the end user. 
+#' @param id (character) Identifier of dataset to read. Identifiers are listed in the "id" column of the \code{search_data()} output. e.g., \code{neon.ecocomdp.20166.001.001} is the \code{id} for "ALGAE Periphyton, seston, and phytoplankton collection" converted to the ecocomDP format from the NEON source data product DP1.20166.001. 
+#' @param neon.data.save.dir (character) Directory to save NEON source data that has been downloaded via \code{neonUtilities::loadByProduct()}
+#' @param neon.data.read.path (character) Path to read in an RDS file of 'stacked NEON data' from \code{neonUtilities::loadByProduct()}
+#' @param neon.data.list (list) A list of stacked NEON data tables to be mapped to ecocomDP. Must match the chosen mapping method in 'id'
 #' @param ... Additional arguments passed to neonUtilities::loadByProduct(). 
 #' @param site Either the string 'all', meaning all available sites, or a character vector of 4-letter NEON site codes, e.g. c('ONAQ','RMNP'). Defaults to all.
 #' @param startdate Either NA, meaning all available dates, or a character vector in the form YYYY-MM, e.g. 2017-01. Defaults to NA.
@@ -25,9 +27,9 @@
 #' @return Returns a named list, including: 
 #' \item{metadata}{A list of information about the NEON data product returned by neonUtilities::getProductInfo.}
 #' \item{tables}{A list of data.frames following the ecocomDP format.}
-#'     \item{location}{A table, which has the lat long for each NEON site included in the data set}
-#'     \item{taxon}{A table, which describes each taxonID that appears in the data set}
-#'     \item{observation}{A table, which describes each taxonID that appears in the data set}
+#'     \item{tables$location}{A table, which has the lat long for each NEON site (\code{location_id}) included in the data set}
+#'     \item{tables$taxon}{A table, which describes each \code{taxon_id} that appears in the data set}
+#'     \item{tables$observation}{A table, with a record for each \code{observation_id} that appears in the data set}
 
 
 #' @examples
@@ -56,58 +58,116 @@
 ##############################################################################################
 map_neon_data_to_ecocomDP <- function(
   id,
+  neon.data.save.dir = NULL,
+  neon.data.read.path = NULL,
+  neon.data.list = NULL,
   ... #arguments set to neonUtilities::loadByProduct
 ){
   
+  # get NEON DPID
+  neon.data.product.id <- id %>% 
+    gsub("neon\\.ecocomdp", "DP1",.) %>% 
+    gsub("\\.[0-9]{3}$","",.)
+  
+  # check arguments passed via dots for neonUtilities
+  dots_updated <- list(..., dpID = neon.data.product.id)
+  
+  #Error handling if user provides a value for "package" other than "expanded"
+  if("package" %in% names(dots_updated) && dots_updated$package != "expanded") message(
+    paste0("WARNING: expanded package for ", neon.data.product.id, 
+           " is required to execute this request. Downloading the expanded package"))
+  
+  dots_updated[["package"]] <- "expanded"
+  
+  
+  # Getting the raw NEON data ----
+  # check if neon.data.list is provided
+  if(is.null(neon.data.list)){
+    
+    #if not, check if a filepath to an RDS file is provided
+    if(!is.null(neon.data.read.path)){
+      neon.data.list <- readRDS(neon.data.read.path)
+      
+      data_access_method_described <- paste0(
+        "original NEON data accessed from file: ",
+        neon.data.read.path)
+      
+      # if not, read data from NEON API
+    }else{
+      neon.data.list <- rlang::exec(
+        neonUtilities::loadByProduct,
+        !!!dots_updated)
+      
+      data_access_method_described <- paste0(
+        "original NEON data accessed using neonUtilities v", 
+        packageVersion("neonUtilities"))
+    }
+  }else{
+    data_access_method_described <- paste0(
+      "original NEON data accessed from R object")
+  }
 
+  
+
+  # save NEON download if given a filepath
+  if(!is.null(neon.data.save.dir)){
+    neon.data.save.dir <- gsub("/$","",neon.data.save.dir)
+    neon_data_filename <- paste0(neon.data.save.dir,"/",
+                                 neon.data.product.id,"_",
+                                 format(Sys.time(), "%Y%m%d%H%M%S"),
+                                 ".RDS")
+    saveRDS(neon.data.list, file = neon_data_filename)
+  }
+
+  
   # call custom mapping function if available for given NEON id
   if(id == "neon.ecocomdp.20166.001.001"){
     #ALGAE method v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20166.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20166.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.20120.001.001"){
     #MACROINVERTEBRATE v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20120.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20120.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10043.001.001"){
     #MOSQUITO v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10043.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10043.001.001(neon.data.list, ...)
   
   }else if(id == "neon.ecocomdp.10022.001.001"){
     #BEETLE v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10022.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10022.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10022.001.002"){
     #HERPETOLOGY v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10022.001.002(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10022.001.002(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10003.001.001"){
     #BIRD v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10003.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10003.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.20107.001.001"){
     #FISH v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20107.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20107.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10058.001.001"){
     #PLANT v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10058.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10058.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10072.001.001"){
     #SMALL_MAMMAL v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10072.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10072.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10093.001.001"){
     #TICK v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10093.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10093.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.20219.001.001"){
     # ZOOPLANKTON (uses MACROINVERTEBRATE NEON taxon table) v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20219.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.20219.001.001(neon.data.list, ...)
     
   }else if(id == "neon.ecocomdp.10092.001.001"){
     # TICK_PATHOGENS (no NEON taxon table) v01
-    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10092.001.001(...)
+    ecocomDP_tables <- ecocomDP:::map_neon.ecocomdp.10092.001.001(neon.data.list, ...)
     
   }else{
     message(paste0("WARNING: ecocomDP mapping not currently available for ",id))
@@ -117,14 +177,7 @@ map_neon_data_to_ecocomDP <- function(
       observation = data.frame())
   }
   
-  # get NEON DPID
-  neon.data.product.id <- id %>% 
-    gsub("neon\\.ecocomdp", "DP1",.) %>% 
-    gsub("\\.[0-9]{3}$","",.)
-  
-  my_dots <- list(...)
-  
-  
+ 
   # get taxon group
   neon_dp_table <- ecocomDP::search_data("NEON")
   taxon_group <- neon_dp_table$title[neon_dp_table$id == id] %>%
@@ -140,13 +193,11 @@ map_neon_data_to_ecocomDP <- function(
         taxonomic_group = taxon_group,
         orig_NEON_data_product_id = neon.data.product.id,
         NEON_to_ecocomDP_mapping_method = id,
-        data_access_method = paste0(
-          "original NEON data accessed using neonUtilities v", 
-          packageVersion("neonUtilities")),
+        data_access_method = data_access_method_described,
         data_access_date_time = Sys.time()),
       orig_NEON_data_product_info = neonUtilities::getProductInfo(
         dpID = neon.data.product.id,
-        token = ifelse("token" %in% names(my_dots), my_dots$token, NA_character_))),
+        token = ifelse("token" %in% names(dots_updated), dots_updated$token, NA_character_))),
     tables = ecocomDP_tables)
   
   # return

--- a/R/read_data.R
+++ b/R/read_data.R
@@ -37,6 +37,15 @@
 #' @param token 
 #'     (character; NEON data only) User specific API token (generated within 
 #'     neon.datascience user accounts)
+#' @param neon.data.save.dir 
+#'     (character) Directory to save NEON source data that has been downloaded 
+#'     via \code{neonUtilities::loadByProduct()}
+#' @param neon.data.read.path 
+#'     (character) Path to read in an RDS file of 'stacked NEON data' from 
+#'     \code{neonUtilities::loadByProduct()}
+#' @param neon.data.list 
+#'     (list) A list of stacked NEON data tables to be mapped to ecocomDP. 
+#'     Must match the chosen mapping method in 'id'
 #' @param globally.unique.keys
 #'     (logical) Whether to create globally unique primary keys (and associated
 #'     foreign keys). Reading multiple datasets raises the issue of referential 

--- a/man/map_neon_data_to_ecocomDP.Rd
+++ b/man/map_neon_data_to_ecocomDP.Rd
@@ -22,38 +22,96 @@
 \alias{map_neon_data_to_ecocomDP}
 \title{Map NEON data products to ecocomDP}
 \usage{
-map_neon.ecocomdp.10003.001.001(neon.data.product.id = "DP1.10003.001", ...)
+map_neon.ecocomdp.10003.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10003.001",
+  ...
+)
 
-map_neon.ecocomdp.10022.001.001(neon.data.product.id = "DP1.10022.001", ...)
+map_neon.ecocomdp.10022.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10022.001",
+  ...
+)
 
-map_neon.ecocomdp.10022.001.002(neon.data.product.id = "DP1.10022.001", ...)
+map_neon.ecocomdp.10022.001.002(
+  neon.data.list,
+  neon.data.product.id = "DP1.10022.001",
+  ...
+)
 
-map_neon.ecocomdp.10043.001.001(neon.data.product.id = "DP1.10043.001", ...)
+map_neon.ecocomdp.10043.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10043.001",
+  ...
+)
 
-map_neon.ecocomdp.10058.001.001(neon.data.product.id = "DP1.10058.001", ...)
+map_neon.ecocomdp.10058.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10058.001",
+  ...
+)
 
-map_neon.ecocomdp.10072.001.001(neon.data.product.id = "DP1.10072.001", ...)
+map_neon.ecocomdp.10072.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10072.001",
+  ...
+)
 
-map_neon.ecocomdp.10092.001.001(neon.data.product.id = "DP1.10092.001", ...)
+map_neon.ecocomdp.10092.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10092.001",
+  ...
+)
 
-map_neon.ecocomdp.10093.001.001(neon.data.product.id = "DP1.10093.001", ...)
+map_neon.ecocomdp.10093.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.10093.001",
+  ...
+)
 
-map_neon.ecocomdp.20107.001.001(neon.data.product.id = "DP1.20107.001", ...)
+map_neon.ecocomdp.20107.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.20107.001",
+  ...
+)
 
-map_neon.ecocomdp.20120.001.001(neon.data.product.id = "DP1.20120.001", ...)
+map_neon.ecocomdp.20120.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.20120.001",
+  ...
+)
 
-map_neon.ecocomdp.20166.001.001(neon.data.product.id = "DP1.20166.001", ...)
+map_neon.ecocomdp.20166.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.20166.001",
+  ...
+)
 
-map_neon.ecocomdp.20219.001.001(neon.data.product.id = "DP1.20219.001", ...)
+map_neon.ecocomdp.20219.001.001(
+  neon.data.list,
+  neon.data.product.id = "DP1.20219.001",
+  ...
+)
 
-map_neon_data_to_ecocomDP(id, ...)
+map_neon_data_to_ecocomDP(
+  id,
+  neon.data.save.dir = NULL,
+  neon.data.read.path = NULL,
+  neon.data.list = NULL,
+  ...
+)
 }
 \arguments{
-\item{neon.data.product.id}{(character) The identifier of the NEON data product to pull from the NEON API and map to the ecocomDP format. This argument is specified in each internal mapping function and is NOT provided by the end user.}
+\item{neon.data.list}{(list) A list of stacked NEON data tables to be mapped to ecocomDP. Must match the chosen mapping method in 'id'}
 
 \item{...}{Additional arguments passed to neonUtilities::loadByProduct().}
 
-\item{id}{(character) Identifier of dataset to read. Identifiers are listed in the "id" column of the \code{search_data()} output. e.g., \code{neon.ecocomdp.20166.001.001} is the data product id for "ALGAE Periphyton, seston, and phytoplankton collection" converted to the ecocomDP format from the NEON source data product DP1.20166.001.}
+\item{id}{(character) Identifier of dataset to read. Identifiers are listed in the "id" column of the \code{search_data()} output. e.g., \code{neon.ecocomdp.20166.001.001} is the \code{id} for "ALGAE Periphyton, seston, and phytoplankton collection" converted to the ecocomDP format from the NEON source data product DP1.20166.001.}
+
+\item{neon.data.save.dir}{(character) Directory to save NEON source data that has been downloaded via \code{neonUtilities::loadByProduct()}}
+
+\item{neon.data.read.path}{(character) Path to read in an RDS file of 'stacked NEON data' from \code{neonUtilities::loadByProduct()}}
 
 \item{site}{Either the string 'all', meaning all available sites, or a character vector of 4-letter NEON site codes, e.g. c('ONAQ','RMNP'). Defaults to all.}
 
@@ -73,9 +131,9 @@ map_neon_data_to_ecocomDP(id, ...)
 Returns a named list, including: 
 \item{metadata}{A list of information about the NEON data product returned by neonUtilities::getProductInfo.}
 \item{tables}{A list of data.frames following the ecocomDP format.}
-    \item{location}{A table, which has the lat long for each NEON site included in the data set}
-    \item{taxon}{A table, which describes each taxonID that appears in the data set}
-    \item{observation}{A table, which describes each taxonID that appears in the data set}
+    \item{tables$location}{A table, which has the lat long for each NEON site (\code{location_id}) included in the data set}
+    \item{tables$taxon}{A table, which describes each \code{taxon_id} that appears in the data set}
+    \item{tables$observation}{A table, with a record for each \code{observation_id} that appears in the data set}
 }
 \description{
 Pull files from the NEON API by data product, merge data for each table, and convert to ecocomDP format. Please see neonUtilities::loadByProduct for more information.
@@ -112,103 +170,6 @@ Dates are specified only to the month because NEON data are provided in monthly 
 }}
 
 \examples{
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10003.001.001(
-  site = c("NIWO","DSNY"),
-  startdate = "2016-01",
-  enddate = "2018-11")
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10022.001.001(
-  site = c('ABBY','BARR'),
-  startdate = "2019-06",
-  enddate = "2019-09")
-                                         
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10022.001.002(
-  site= c("NIWO","DSNY"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-  
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10043.001.001(
-  site = c("NIWO","DSNY"),
-  startdate = "2016-01",
-  enddate = "2018-11")
-
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10058.001.001(
-  site= c("NIWO","DSNY"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-  
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10072.001.001(
-  site = c("NIWO","DSNY"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10092.001.001(
-  site = c("ORNL","OSBS"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.10093.001.001(
-  site = c("BART","DSNY"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-
-}
-\dontrun{
-my_result <- map_neon.ecocomdp.20107.001.001(
-  site = c(c('COMO','LECO')),
-  startdate = "2016-01",
-  enddate = "2018-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-}
-\dontrun{
-
-my_result <- map_neon.ecocomDP.20120.001.001(
-  site= c('COMO','LECO'),
-  startdate = "2019-06",
-  enddate = "2019-09")
-}
-\dontrun{
-
-my_result <- map_neon.ecocomdp.20219.001.001(
-  site = c("BARC","SUGG"),
-  startdate = "2016-01",
-  enddate = "2017-11",
-  token = Sys.getenv("NEON_TOKEN"),
-  check.size = FALSE)
-}
 \dontrun{
 # Retrieve and map NEON ALGAE data to ecocomDP format
 my_result <- ecocomDP:::map_neon_data_to_ecocomDP(

--- a/man/read_data.Rd
+++ b/man/read_data.Rd
@@ -54,6 +54,15 @@ to FALSE.}
 
 \item{token}{(character; NEON data only) User specific API token (generated within 
 neon.datascience user accounts)}
+
+\item{neon.data.save.dir}{(character) Directory to save NEON source data that has been downloaded 
+via \code{neonUtilities::loadByProduct()}}
+
+\item{neon.data.read.path}{(character) Path to read in an RDS file of 'stacked NEON data' from 
+\code{neonUtilities::loadByProduct()}}
+
+\item{neon.data.list}{(list) A list of stacked NEON data tables to be mapped to ecocomDP. 
+Must match the chosen mapping method in 'id'}
 }
 \value{
 (list) A named list of \code{id}, each including: 


### PR DESCRIPTION
@clnsmth 

I made some changes to the NEON mapping functions so that the actual call to neonUtilities happens in the parent/wrapper function, and the mapping methods just map the data. Added some arguments in the call to map_neon_to_ecocomDP for saving and reading data pulled from the NEON API via neonUtilities::loadByProduct() locally, so we don't have to download from the API every time we want to map the data. 