### PR TITLE
improve consistency with `event_id` and `neon_event_id` in NEON data packages

### DIFF
--- a/NEON_dev_script/NOTES_on_edits_to_NEON_SS_scripts.txt
+++ b/NEON_dev_script/NOTES_on_edits_to_NEON_SS_scripts.txt
@@ -22,21 +22,21 @@ TODO --
 		add "aggregation" choice (none vs mean vs sum) for within group for a given value x. 
 		
 
---------------------------------------------------------
- taxon	 			var name 		units
--------------------------------------------------------
- BEETLES			abundance		count per trap day
- ALGAE				cell density	cells/cm2 OR cells/mL
- MACROINVERTEBRATE	density			count per square meter
- MOSQUITO			abundance		count per trap hour
- BIRD				cluster size	count of individuals
- FISH				abundance		catch per unit effort
- HERPTILES			abundance		count per trap day
- PLANT				percent cover	percent of plot area covered by taxon
- SMALL_MAMMAL		count			unique individuals per 100 trap nights per plot per month
- ZOOPLANKTON		density			count per liter
- TICK				abundance		count per square meter 
- TICK_PATHOGENS		positivity rate	positive tests per pathogen per sampling event
+-----------------------------------------------------------------------------------------------------------------
+ taxon	 			grouping var													var name 		units		
+-----------------------------------------------------------------------------------------------------------------
+ BEETLES			neon_event_id (namedLocation(plotID),trapID,boutIDdate)			abundance		count per trap day
+ ALGAE				event_id (which is sampleID)									cell density	cells/cm2 OR cells/mL
+ MACROINVERTEBRATE	event_id (which is sampleID)									density			count per square meter
+ MOSQUITO			neon_event_id(siteID, year, bout)								abundance		count per trap hour
+ BIRD				neon_event_id(plot,point,date,time)								cluster size	count of individuals
+ FISH				neon_event_id(site,date,reach,rep,sampler)						abundance		catch per unit effort
+ HERPTILES			neon_event_id(namedLocation(plotID),trapID,boutIDdate)			abundance		count per trap day
+ PLANT				neon_event_id(namedLocation(plotID),100m2plotID,year,bout#)		percent cover	percent of plot area covered by taxon
+ SMALL_MAMMAL		neon_event_id(location_id,year,month)							count			unique individuals per 100 trap nights per plot per month
+ ZOOPLANKTON		event_id (which is sampleID)									density			count per liter
+ TICK				neon_event_id(plotID,collectDate)								abundance		count per square meter 
+ TICK_PATHOGENS		event_id(plotID,collectDate)									positivity rate	positive tests per pathogen per sampling event
  
 ##################################################################
 BEETLES -- map_neon.ecocomdp.10022.001.001

--- a/NEON_dev_script/TESTING_20200322.R
+++ b/NEON_dev_script/TESTING_20200322.R
@@ -1,0 +1,231 @@
+###############################################
+###############################################
+# PLANT
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10058.001.001",
+  neon.data.read.path = "my_result/DP1.10058.001_20210320222014.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# BIRDS
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10003.001.001",
+  neon.data.read.path = "my_result/DP1.10003.001_20210320221508.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+
+###############################################
+###############################################
+# BEETLES
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10022.001.001",
+  neon.data.read.path = "my_result/DP1.10022.001_20210320221443.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# HERPS
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10022.001.002",
+  neon.data.read.path = "my_result/DP1.10022.001_20210320221443.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# MOSQUITO
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10043.001.001",
+  neon.data.read.path = "my_result/DP1.10043.001_20210320221902.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+
+###############################################
+###############################################
+# SMALL_MAMMAL
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10072.001.001",
+  neon.data.read.path = "my_result/DP1.10072.001_20210320222054.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+
+###############################################
+###############################################
+# TICK_PATHOGEN
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10092.001.001",
+  neon.data.read.path = "my_result/DP1.10092.001_20210320222153.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+
+###############################################
+###############################################
+# TICKS
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.10093.001.001",
+  neon.data.read.path = "my_result/DP1.10093.001_20210320222321.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# FISH
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20107.001.001",
+  neon.data.read.path = "my_result/DP1.20107.001_20210320222348.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# MACROINVERTEBRATE
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20120.001.001",
+  neon.data.read.path = "my_result/DP1.20120.001_20210320222420.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# ALGAE
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20166.001.001",
+  neon.data.read.path = "my_result/DP1.20166.001_20210320222638.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)
+
+###############################################
+###############################################
+# ZOOPS
+
+rm(list = ls())
+
+my_result_read_data <- read_data(
+  id = "neon.ecocomdp.20219.001.001",
+  neon.data.read.path = "my_result/DP1.20219.001_20210320222716.RDS")
+
+my_result_read_data[[1]]$validation_issues
+my_result_read_data[[1]]$metadata$data_package_info
+
+tab_flat <- my_result_read_data[[1]]$tables %>% 
+  ecocomDP::flatten_ecocomDP() %>% 
+  as.data.frame()
+
+View(tab_flat)

--- a/R/map_neon.ecocomdp.10022.001.001.R
+++ b/R/map_neon.ecocomdp.10022.001.001.R
@@ -189,6 +189,7 @@ map_neon.ecocomdp.10022.001.001 <- function(
   # All individuals of the same species collected at the same time/same location are considered the same observation, regardless of how they were ID'd
   my_package_id <- paste0(neon_method_id, ".", format(Sys.time(), "%Y%m%d%H%M%S"))
   
+
   table_observation_raw <- beetles_counts %>%
     dplyr::rename(
       location_id = namedLocation,
@@ -202,8 +203,13 @@ map_neon.ecocomdp.10022.001.001 <- function(
       variable_name = "abundance",
       value = abundance/trappingDays,
       unit = "count per trap day") %>%
+    dplyr::rowwise() %>%
+    dplyr::mutate(
+      neon_event_id = paste0(location_id, "_", trapID, "_", gsub("^(?i)[a-z]{4}_","",boutID))) %>%
+    dplyr::ungroup() %>%
     dplyr::distinct()
   
+
   table_observation <- table_observation_raw %>% 
     dplyr::select(observation_id,
                   event_id,
@@ -223,6 +229,7 @@ map_neon.ecocomdp.10022.001.001 <- function(
     obs_wide = table_observation_raw,
     ancillary_var_names = c(
       "event_id",
+      "neon_event_id",
       "sampleID",
       "boutID",
       "trapID",

--- a/R/map_neon.ecocomdp.10022.001.002.R
+++ b/R/map_neon.ecocomdp.10022.001.002.R
@@ -229,12 +229,13 @@ map_neon.ecocomdp.10022.001.002 <- function(
   
   # #1. Only want samples with herps
   data_herp_bycatch <- dplyr::filter(data_herp_bycatch, sampleType == "vert bycatch herp",
-                              (is.na(sampleCondition) | sampleCondition == "OK")) %>%
-    dplyr::select(-boutID, # just siteID and colectDate
-           -sampleCollected, # all Y
-           -sampleID,  -sampleCondition, -samplingImpractical,
-           -eventID_raw, -subsampleID,
-           -sampleType # all "vert bycatch herp"
+                                     (is.na(sampleCondition) | sampleCondition == "OK")) %>%
+    dplyr::select(
+      # -boutID, # just siteID and colectDate
+      -sampleCollected, # all Y
+      -sampleID,  -sampleCondition, -samplingImpractical,
+      -eventID_raw, -subsampleID,
+      -sampleType # all "vert bycatch herp"
     )
   
   
@@ -306,14 +307,17 @@ map_neon.ecocomdp.10022.001.002 <- function(
       neon_trap_id = trapID) %>%
     dplyr:: rename(
       observation_id = uid, 
-      neon_event_id = eventID,
       observation_datetime = setDate, 
       taxon_id = taxonID,
       value = individualCount/trappingDays) %>%
     dplyr::mutate(
       event_id = observation_id,
       variable_name = "abundance",
-      unit = "count per trap day") 
+      unit = "count per trap day") %>%
+    dplyr::rowwise() %>%
+    dplyr::mutate(
+      neon_event_id = paste0(location_id, "_", neon_trap_id, "_", gsub("^(?i)[a-z]{4}_","",boutID))) %>%
+    dplyr::ungroup()
   
   table_observation <- table_observation_wide_all %>%
     dplyr::select(

--- a/R/map_neon.ecocomdp.10043.001.001.R
+++ b/R/map_neon.ecocomdp.10043.001.001.R
@@ -260,10 +260,9 @@ map_neon.ecocomdp.10043.001.001 <- function(
   
   
   table_observation_raw <- mos_dat %>% 
-  dplyr::mutate(variable_name = "abundance",
-                value = (individualCount/subsampleWeight) * totalWeight / trapHours,
-                unit = "count per trap hour") %>% 
-    
+    dplyr::mutate(variable_name = "abundance",
+                  value = (individualCount/subsampleWeight) * totalWeight / trapHours,
+                  unit = "count per trap hour") %>% 
     dplyr::rename(
       observation_id = uid,
       neon_event_id = eventID,
@@ -297,6 +296,7 @@ map_neon.ecocomdp.10043.001.001 <- function(
     obs_wide = table_observation_raw,
     ancillary_var_names = c(
       "event_id",
+      "neon_event_id",
       "sortDate",
       "sampleID",
       "subsampleID",

--- a/R/map_neon.ecocomdp.10058.001.001.R
+++ b/R/map_neon.ecocomdp.10058.001.001.R
@@ -103,17 +103,16 @@ map_neon.ecocomdp.10058.001.001 <- function(
     tibble::as_tibble()
   
   
-  data_plant = dplyr::distinct(data_plant)
+  data_plant <- dplyr::distinct(data_plant)
   
   # family or order level data are pretty much not useful.
-  data_plant = dplyr::filter(
+  data_plant <- dplyr::filter(
     data_plant, 
     taxonRank %in% c("variety", "subspecies", "species", "speciesGroup", "genus"))
   # NOTE: we have not cleaned species names; users need to do it
   
+ 
   
-  
-
   #location ----
   table_location_raw <- data_plant %>%
     dplyr::select(domainID, siteID, plotID, namedLocation, 
@@ -163,10 +162,17 @@ map_neon.ecocomdp.10058.001.001 <- function(
       observation_datetime = endDate, 
       taxon_id = taxonID,
       value = percentCover) %>%
+    dplyr::rowwise() %>%
     dplyr::mutate(
       event_id = observation_id,
+      neon_event_id = paste0(location_id,"_",subplot_id,"_",year,"-",boutNumber),
       variable_name = "percent cover",
-      unit = "percent of plot area covered by taxon") 
+      unit = "percent of plot area covered by taxon",
+      presence_absence = 1) %>%
+    dplyr::ungroup()
+  
+  
+  
   
   table_observation <- table_observation_wide_all %>%
     dplyr::select(
@@ -189,8 +195,11 @@ map_neon.ecocomdp.10058.001.001 <- function(
     obs_wide = table_observation_wide_all,
     ancillary_var_names = c(
       "event_id",
+      "neon_event_id",
+      "subplotID", 
       "boutNumber",
-      "subplotID",
+      # "subplot_id",
+      # "subsubplot_id",
       "nativeStatusCode",
       "identificationReferences",
       "nativeStatusCode",

--- a/R/map_neon.ecocomdp.10072.001.001.R
+++ b/R/map_neon.ecocomdp.10072.001.001.R
@@ -166,7 +166,7 @@ map_neon.ecocomdp.10072.001.001 <- function(
       observation_datetime = collectDate, 
       taxon_id = taxonID) %>%
     dplyr::mutate(
-      neon_event_id = paste(year, month, location_id, sep = "_")) %>%
+      neon_event_id = paste(location_id, year, month, sep = "_")) %>%
     dplyr::ungroup() %>%
     dplyr::mutate(
       occurrence = 1)

--- a/R/map_neon.ecocomdp.10092.001.001.R
+++ b/R/map_neon.ecocomdp.10092.001.001.R
@@ -202,6 +202,7 @@ map_neon.ecocomdp.10092.001.001 <- function(
     dplyr::mutate(
       package_id = my_package_id,
       event_id = paste0(namedLocation,"_",collectDate),
+      neon_event_id = event_id,
       pos_result_count = dplyr::case_when(
         testResult == "Positive" ~ 1,
         TRUE ~ 0),
@@ -275,6 +276,7 @@ map_neon.ecocomdp.10092.001.001 <- function(
     obs_wide = event_data,
     ancillary_var_names = c(
       "event_id",
+      # "neon_event_id",
       "n_tests",
       "n_positive_tests",
       "vectorSpecies ",

--- a/R/map_neon.ecocomdp.20120.001.001.R
+++ b/R/map_neon.ecocomdp.20120.001.001.R
@@ -193,7 +193,7 @@ map_neon.ecocomdp.20120.001.001 <- function(
     ancillary_var_names = c(
       "event_id",
       "neon_sample_id",
-      "neon_event_id",
+      # "neon_event_id",
       "subsamplePercent",
       "laboratoryName",
       "benthicArea",

--- a/R/map_neon.ecocomdp.20166.001.001.R
+++ b/R/map_neon.ecocomdp.20166.001.001.R
@@ -180,21 +180,23 @@ map_neon.ecocomdp.20166.001.001 <- function(
   
   table_observation_ancillary <- ecocomDP:::make_neon_ancillary_observation_table(
     obs_wide = table_observation_ecocomDP,
-    ancillary_var_names = c("neon_sample_id",
-                            "neon_event_id",
-                            "parentSampleID",
-                            "sampleCondition",
-                            "laboratoryName",
-                            "perBottleSampleVolume",
-                            "algalSampleType",
-                            "samplerType",
-                            "habitatType",
-                            "benthicArea",
-                            "samplingProtocolVersion",
-                            "phytoDepth1","phytoDepth2","phytoDepth3",
-                            "substratumSizeClass",
-                            "release",
-                            "publicationDate"))
+    ancillary_var_names = c(
+      "event_id",
+      "neon_sample_id",
+      # "neon_event_id",
+      "parentSampleID",
+      "sampleCondition",
+      "laboratoryName",
+      "perBottleSampleVolume",
+      "algalSampleType",
+      "samplerType",
+      "habitatType",
+      "benthicArea",
+      "samplingProtocolVersion",
+      "phytoDepth1","phytoDepth2","phytoDepth3",
+      "substratumSizeClass",
+      "release",
+      "publicationDate"))
   
 
   

--- a/R/map_neon.ecocomdp.20219.001.001.R
+++ b/R/map_neon.ecocomdp.20219.001.001.R
@@ -150,7 +150,7 @@ map_neon.ecocomdp.20219.001.001 <- function(
     obs_wide = table_observation_wide_all,
     ancillary_var_names = c(
       "event_id",
-      "neon_event_id",
+      # "neon_event_id",
       "neon_sample_id",
       "samplerType",
       "towsTrapsVolume",


### PR DESCRIPTION
update to NEON data packages:
 - when `event_id` is the appropriate grouping variable, `neon_event_id` is not included in the ancillary data.
 - when `neon_event_id` is included in the data, it is because `event_id` had to be mapped one-to-one to `observation_id` so that ancillary data could be included at the observation level. In this case, `neon_event_id` is included as the appropriate grouping variable for observations of community composition. 
 - incorporated updates to NEON ticks, plants, and birds. 