### PR TITLE
Update get_eol function

### DIFF
--- a/R/EAL_make_eml.R
+++ b/R/EAL_make_eml.R
@@ -1227,8 +1227,7 @@ EAL_make_eml <- function(
             numHeaderLines = "1",
             recordDelimiter = get_eol(
               path = data.path,
-              file.name = k,
-              os = detect_os()),
+              file.name = k),
             attributeOrientation = "column",
             url = "placeholder"))
         

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -839,9 +839,6 @@ get_attr_defs <- function(eml) {
 
 
 
-
-
-
 # Get end of line (EOL) character
 #
 # @description
@@ -851,75 +848,16 @@ get_attr_defs <- function(eml) {
 #     (character) A path to the target file directory.
 # @param file.name
 #     (character) The target file name.
-# @param os
-#     (character) The operating system in which this function is called
-#     called. Valid options are generated from \code{detect_os}.
 #
 # @return
 #     A character string representation of the EOL character.
 #
-get_eol <- function(path, file.name, os){
-  
-  # Validate file.name
-  
+get_eol <- function(path, file.name){
   file_name <- validate_file_names(path, file.name)
-  
-  # Detect end of line character
-  
-  if (os == 'mac'){ # Macintosh OS
-    
-    command <- paste0(
-      'od -c "',
-      path,
-      '/',
-      file.name,
-      '"'
-    )
-    
-    output <- system(
-      command,
-      intern = T
-    )
-    
-    use_i <- stringr::str_detect(
-      output,
-      '\\\\r  \\\\n'
-    )
-    
-    if (sum(use_i) > 0){
-      eol <- '\\r\\n'
-    } else {
-      use_i <- stringr::str_detect(
-        output,
-        '\\\\n'
-      )
-      if (sum(use_i) > 0){
-        eol <- '\\n'
-      } else {
-        eol <- '\\r'
-      }
-    }
-    
-  } else if ((os == 'win') | (os == 'lin')){ # Windows & Linux OS
-    
-    output <- readChar(
-      paste0(
-        path,
-        '/',
-        file.name
-      ),
-      nchars = 10000
-    )
-    
-    eol <- parse_delim(output)
-    
-  }
-  
-  eol
-  
+  output <- readChar(paste0(path, '/', file.name), nchars = 10000)
+  eol <- parse_delim(output)
+  return(eol)
 }
-
-
 
 
 

--- a/tests/testthat/test_utilities.R
+++ b/tests/testthat/test_utilities.R
@@ -245,3 +245,43 @@ testthat::test_that("write_tables()", {
   # Clean up
   unlink(mypath, recursive = TRUE)
 })
+
+
+# get_eol -----------------------------------------------------------------
+
+test_that("get_eol works", {
+  
+  # Create tempfiles
+  
+  tmp_newline <- tempfile(fileext = '.txt')
+  tmp_carriage <- tempfile(fileext = '.txt')
+  tmp_carriage_newline <- tempfile(fileext = '.txt')
+  
+  # Create text
+  
+  newline <- paste(rep("A line\n", 10), collapse = "")
+  carriage <- paste(rep("A line\r", 10), collapse = "")
+  carriage_newline <- paste(rep("A line\r\n", 10), collapse = "")
+  
+  # Put test text into temp files
+  
+  writeChar(newline, tmp_newline, eos = NULL, useBytes = TRUE)
+  writeChar(carriage, tmp_carriage, eos = NULL, useBytes = TRUE)
+  writeChar(carriage_newline, tmp_carriage_newline, eos = NULL, useBytes = TRUE)
+  
+  # Test expectations
+  
+  expect_equal(
+    object = get_eol(tempdir(), file.name = basename(tmp_newline)),
+    expected = "\\n"
+  )
+  expect_equal(
+    object = get_eol(tempdir(), file.name = basename(tmp_carriage)),
+    expected = "\\r"
+  )
+  expect_equal(
+    object = get_eol(tempdir(), file.name = basename(tmp_carriage_newline)),
+    expected = "\\r\\n"
+  )
+  
+})


### PR DESCRIPTION
The get_eol function was refactored for efficiency and clarity in the hymetDP
package. These changes, including new unit test and updated instances, are now
ported over to ecocomDP.

Add test for the new get_eol function

This test was developed in the hymetDP package but since the function and test
should be essentially the same, it is a direct copy.

Remove unused argument from get_eol instance