### PR TITLE
Remove mapped_id URI resolution check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # ecocomDP 1.X.X
 
+## Fixes
+* Remove mapped_id URI resolution check [#173](https://github.com/EDIorg/ecocomDP/issues/173)
+
 ## Documentation
 * Consolidate duplicated model documentation [#166](https://github.com/EDIorg/ecocomDP/issues/166)
 

--- a/R/validate_data.R
+++ b/R/validate_data.R
@@ -99,7 +99,6 @@ validate_data <- function(
     validate_latitude_longitude_range(d)
   issues_validate_elevation <- validate_elevation(d)
   issues_validate_variable_mapping <- validate_variable_mapping(d)
-  issues_validate_mapped_id <- validate_mapped_id(d)
   
   # Report validation issues
   
@@ -118,8 +117,7 @@ validate_data <- function(
       issues_validate_latitude_longitude_format,
       issues_validate_latitude_longitude_range,
       issues_validate_elevation,
-      issues_validate_variable_mapping,
-      issues_validate_mapped_id))
+      issues_validate_variable_mapping))
   
   if (length(validation_issues) != 0) {
     warning("  Validation issues found for ", id, call. = FALSE)
@@ -745,48 +743,3 @@ validate_variable_mapping <- function(data.list) {
     return(unlist(output))
   }
 }
-
-
-
-
-#' Check mapped_id
-#' 
-#' @param data.list (list) A named list of data frames, each of which is an ecocomDP table.
-#'
-#' @return (character) If mapped_id does not resolve with a status of 200, then a message is returned.
-#' 
-#' @details This function is slow to execute due to API calls for each variable listed in the variable_mapping table. To shorten wait times for \code{read_data()} operations against the archive of resolvable annotations, this function only executes during:
-#' \itemize{
-#'   \item the validation step of the "create ecocomDP dataset" workflow (i.e. when \code{validate_data()} is called with a \code{path} argument).
-#'   \item a direct call from a unit test
-#' }
-#'     
-#' @noRd
-#'
-validate_mapped_id <- function(data.list) {
-  callstack <- as.character(sys.calls())
-  continue <- any(stringr::str_detect(callstack, "validate_data\\(path")) | # when checking files at path
-    any(stringr::str_detect(callstack, "test_that\\(")) # when unit testing
-  if (continue) {
-    if ("variable_mapping" %in% names(data.list)) {
-      message("  mapped_id")
-      output <- lapply(
-        unique(data.list$variable_mapping$mapped_id),
-        function(m_id) {
-          m_id <- trimws(m_id)
-          i <- try(httr::GET(m_id)$status, silent = T)
-          if (i != 200 & !is.na(m_id)) {
-            paste(m_id)
-          }
-        })
-      output <- unlist(output)
-      if (!is.null(output)) {
-        output <- paste0("Variable mapping. The variable_mapping table has ",
-                         "these mapped_id values that don't resolve: ",
-                         paste(unlist(output), collapse = ", "))
-      }
-      return(output)
-    }
-  }
-}
-

--- a/tests/testthat/test_validate_data.R
+++ b/tests/testthat/test_validate_data.R
@@ -413,33 +413,6 @@ testthat::test_that("validate_variable_mapping()", {
   }
 })
 
-
-# validate_mapped_id() --------------------------------------------------------
-
-testthat::test_that("validate_mapped_id()", {
-  
-  testthat::skip_on_cran()
-  
-  for (i in c("df", "tbbl")) {
-    # Parameterize
-    test_data <- ants_L1
-    if (i == "df") { # test w/data.frame
-      for (tbl in names(test_data$tables)) {
-        test_data$tables[[tbl]] <- as.data.frame(test_data$tables[[tbl]])
-      }
-    }
-    d <- test_data$tables
-    d$variable_mapping <- d$variable_mapping[1, ]
-    # Valid mapped_id results in message.
-    expect_null(validate_mapped_id(d))
-    # Invalid mapped_id results in character string
-    d$variable_mapping$mapped_id <- "shttp://rs.tdwg.org/dwc/terms/measurementType"
-    resp <- validate_mapped_id(d)
-    res <- stringr::str_detect(resp, "mapped_id values that don't resolve:.+")
-    expect_true(res)
-  }
-})
-
 # validate_data() ---------------------------------------------------------
 
 testthat::test_that("validate_data", {


### PR DESCRIPTION
Remove the validate_mapped_id function, from the validation suite, due to it being brittle, slow, and unreliable.

Resolves #173

Related to #172